### PR TITLE
Suppress input event for partial date ranges

### DIFF
--- a/lib/coprl/presenters/dsl/components/datetime_base.rb
+++ b/lib/coprl/presenters/dsl/components/datetime_base.rb
@@ -29,13 +29,13 @@ module Coprl
           end
 
           private
-          def merge_config(attrib, default=false)
-            attrib_value = attribs.delete(attrib) {default ? default(attrib) : nil}
+          def merge_config(attrib, use_default=false)
+            attrib_value = attribs.delete(attrib) {use_default ? default(attrib) : nil}
             @config.merge!({attrib => attrib_value}) if attrib_value
           end
 
-          def map_config(attrib, new_attrib, default=false)
-            attrib_value = attribs.delete(attrib) {default ? default(attrib) : nil}
+          def map_config(attrib, new_attrib, use_default=false)
+            attrib_value = attribs.delete(attrib) {use_default ? default(attrib) : nil}
             @config.merge!({new_attrib => attrib_value}) if attrib_value
           end
         end

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -4102,7 +4102,6 @@ module.exports = DESCRIPTORS ? function (object, key, value) {
     component: {
         datetime: {
             flatpickr: {
-                altInput: true,
                 disableMobile: true,
                 clickOpens: false,
                 defaultHour: 0
@@ -45172,6 +45171,17 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+// field types:
+var TYPE_DATE = 'date';
+var TYPE_TIME = 'time';
+var TYPE_DATE_TIME = 'datetime';
+
+// date/time selection modes:
+// (see https://flatpickr.js.org/options, option `mode`)
+var MODE_SINGLE = 'single';
+var MODE_MULTIPLE = 'multiple';
+var MODE_RANGE = 'range';
+
 function initDateTime(e) {
     console.debug('\tDateTime');
     Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["c" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["a" /* MDCTextField */]);
@@ -45186,16 +45196,17 @@ var VDateTime = function (_VTextField) {
 
         var _this = _possibleConstructorReturn(this, (VDateTime.__proto__ || Object.getPrototypeOf(VDateTime)).call(this, element, mdcComponent));
 
-        var type = element.dataset.type;
-        var defaultConfig = {};
+        var defaultConfig = { altInput: true };
+
         if (!_this.root.documentElement) {
             defaultConfig.appendTo = _this.root.querySelector('.v-root');
         }
+
         var config = Object.assign(defaultConfig, __WEBPACK_IMPORTED_MODULE_4__config__["a" /* default */].get('component.datetime.flatpickr', {}), JSON.parse(element.dataset.config));
 
-        if (type === 'datetime') {
+        if (_this.type === TYPE_DATE_TIME) {
             config.enableTime = true;
-        } else if (type === 'time') {
+        } else if (_this.type === TYPE_TIME) {
             config.enableTime = true;
             config.noCalendar = true;
         }
@@ -45211,6 +45222,19 @@ var VDateTime = function (_VTextField) {
 
         _this.fp = __WEBPACK_IMPORTED_MODULE_0_flatpickr___default()(_this.input, config);
         _this.fp.mdc_text_field = mdcComponent;
+
+        // Avoid dispatching `input` event before both ends of a date range have
+        // been selected:
+        if (_this.mode == MODE_RANGE) {
+            _this.input.addEventListener('input', function (e) {
+                // not `< 2` because `selectedDates.length` will be 0 when the
+                // selector is cleared via the ✕ button.
+                if (_this.fp.selectedDates.length == 1) {
+                    e.stopPropagation();
+                    return false;
+                }
+            });
+        }
 
         element.addEventListener('click', function () {
             return _this.toggle();
@@ -45257,6 +45281,22 @@ var VDateTime = function (_VTextField) {
             var currVal = new Date(this.fp.input.value);
             var prevVal = new Date(this.originalValue);
             return currVal.getTime() !== prevVal.getTime();
+        }
+    }, {
+        key: 'mode',
+        get: function get() {
+            if (!this._mode) {
+                var config = JSON.parse(this.element.dataset['config']) || {};
+
+                this._mode = config['mode'] || MODE_SINGLE; // default per Flatpickr
+            }
+
+            return this._mode;
+        }
+    }, {
+        key: 'type',
+        get: function get() {
+            return this.element.dataset['type'];
         }
     }]);
 

--- a/public/style-bundle.js
+++ b/public/style-bundle.js
@@ -65,9 +65,9 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-module.exports = __webpack_require__.p + "../../public/bundle.css";
+throw new Error("Module build failed: Error: Missing binding /Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/vendor/darwin-x64-57/binding.node\nNode Sass could not find a binding for your current environment: OS X 64-bit with Node.js 8.x\n\nFound bindings for the following environments:\n  - OS X 64-bit with Node.js 10.x\n\nThis usually happens because your environment has changed since running `npm install`.\nRun `npm rebuild node-sass` to download the binding for your current environment.\n    at module.exports (/Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/lib/binding.js:15:13)\n    at Object.<anonymous> (/Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/lib/index.js:14:35)\n    at Module._compile (module.js:624:30)\n    at Object.Module._extensions..js (module.js:635:10)\n    at Module.load (module.js:545:32)\n    at tryModuleLoad (module.js:508:12)\n    at Function.Module._load (module.js:500:3)\n    at Module.require (module.js:568:17)\n    at require (internal/module.js:11:18)\n    at Object.sassLoader (/Users/nick/Projects/coprl/views/mdc/node_modules/sass-loader/lib/loader.js:46:72)");
 
 /***/ })
 /******/ ]);

--- a/views/mdc/assets/js/config.js
+++ b/views/mdc/assets/js/config.js
@@ -4,7 +4,6 @@ export default new VConfig({
     component: {
         datetime: {
             flatpickr: {
-                altInput: true,
                 disableMobile: true,
                 clickOpens: false,
                 defaultHour: 0


### PR DESCRIPTION
Previously when working with a `date_field` or `datetime_field` with `mode: :range`, the underlying `<input>` element would dispatch an `input` event when both the start and end dates of the range were chosen. This caused containing forms to be submitted twice: once with just the start date and no end date, and again with both the start and end date.

This change prevents range date/time fields with `mode: :range` from generating an `input` event before both ends of the range have been selected.

Date/time fields that are not operating with `mode: :range` continue to dispatch events as normal.