### PR TITLE
Add missing disabled class to radio buttons

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-ub1efe608 {
+@keyframes mdc-checkbox-fade-in-background-uc18bfa1c {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-ub1efe608 {
+@keyframes mdc-checkbox-fade-out-background-uc18bfa1c {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-ub1efe608; }
+  animation-name: mdc-checkbox-fade-in-background-uc18bfa1c; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-ub1efe608; }
+  animation-name: mdc-checkbox-fade-out-background-uc18bfa1c; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -15887,7 +15887,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-u177c1ecd {
+@keyframes mdc-checkbox-fade-in-background-ud13270d5 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -15899,7 +15899,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-u177c1ecd {
+@keyframes mdc-checkbox-fade-out-background-ud13270d5 {
   0%,
   80% {
     border-color: #5488b2;
@@ -15915,12 +15915,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u177c1ecd; }
+  animation-name: mdc-checkbox-fade-in-background-ud13270d5; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u177c1ecd; }
+  animation-name: mdc-checkbox-fade-out-background-ud13270d5; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }

--- a/public/style-bundle.js
+++ b/public/style-bundle.js
@@ -65,9 +65,9 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed: Error: Missing binding /Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/vendor/darwin-x64-57/binding.node\nNode Sass could not find a binding for your current environment: OS X 64-bit with Node.js 8.x\n\nFound bindings for the following environments:\n  - OS X 64-bit with Node.js 10.x\n\nThis usually happens because your environment has changed since running `npm install`.\nRun `npm rebuild node-sass` to download the binding for your current environment.\n    at module.exports (/Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/lib/binding.js:15:13)\n    at Object.<anonymous> (/Users/nick/Projects/coprl/views/mdc/node_modules/node-sass/lib/index.js:14:35)\n    at Module._compile (module.js:624:30)\n    at Object.Module._extensions..js (module.js:635:10)\n    at Module.load (module.js:545:32)\n    at tryModuleLoad (module.js:508:12)\n    at Function.Module._load (module.js:500:3)\n    at Module.require (module.js:568:17)\n    at require (internal/module.js:11:18)\n    at Object.sassLoader (/Users/nick/Projects/coprl/views/mdc/node_modules/sass-loader/lib/loader.js:46:72)");
+module.exports = __webpack_require__.p + "../../public/bundle.css";
 
 /***/ })
 /******/ ]);

--- a/views/mdc/components/_radio_button.erb
+++ b/views/mdc/components/_radio_button.erb
@@ -1,4 +1,5 @@
-<div class="v-form-field mdc-form-field">
+<div class="v-form-field mdc-form-field
+            <% if comp.disabled %>mdc-radio--disabled<% end %>">
   <div id="<%= comp.id %>"
        <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
        <% if comp.dirtyable %>data-dirtyable<% end %>
@@ -8,7 +9,8 @@
            id="<%= comp.id %>-input"
            <% if comp.value %>value="<%= comp.value %>"<% end %>
            name="<%= comp.name %>"
-           <%if comp.checked%> checked<%end%><%if comp.disabled%> disabled<%end%>
+           <% if comp.checked %>checked<% end %>
+           <% if comp.disabled %>disabled<% end %>
            <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
     <div class="mdc-radio__background">
       <div class="mdc-radio__outer-circle"></div>


### PR DESCRIPTION
fix(radio-button): add missing disabled class

Disabled radio buttons should be decorated in two ways:
1) the native `<input>` element should have the `disabled` attribute
2) the MDC wrapper element should have the `mdc-radio--disabled` class

Without both of these present, the radio button may appear visually
enabled or would submit values.

This change adds the missing `mdc-radio--disabled` class to the
top-level MDC wrapper element, ensuring it is both visually disabled and
does not submit its value.