### PR TITLE
Remove text_field `password` attribute

### DIFF
--- a/lib/coprl/presenters/dsl/components/text_field.rb
+++ b/lib/coprl/presenters/dsl/components/text_field.rb
@@ -18,7 +18,7 @@ module Coprl
             @full_width = attribs.delete(:full_width){ true }
             @case_type = validate_case_type(attribs.delete(:case_type) { :mixed })
             @auto_complete = validate_auto_complete(attribs.delete(:auto_complete) { :off })
-            @behavior = determine_behavior(attribs.delete(:password), attribs.delete(:behavior))
+            @behavior = attribs.delete(:behavior)
             label(attribs.delete(:label))if attribs.key?(:label)
             value(attribs.delete(:value))if attribs.key?(:value)
             expand!
@@ -87,24 +87,6 @@ module Coprl
 
             raise Errors::ParameterValidation, "Invalid case type specified: #{case_type}" unless VALID_CASE_TYPES.include?(case_type)
             case_type
-          end
-
-          def determine_behavior(password, behavior)
-            unless password.nil?
-              logger.warn(
-                'The `password` attribute of text_field is deprecated. ' \
-                'Use `text_field behavior: :password` instead.'
-              )
-            end
-
-            case password
-            when nil
-              behavior
-            when true
-              :password
-            when false
-              :text
-            end
           end
         end
       end


### PR DESCRIPTION
chore(text-field): Remove `password` attribute

This attribute has been deprecated for some time. Usages have been emitting a warning.

BREAKING CHANGE: `text_field password: true` now creates a plain `text` (i.e. unmasked!) input

This change removes the warning and the intermediate behavior of mapping `text_field password: true` to `text_field behavior: :password`. Migrate password fields using the deprecated `password: true` attribute and syntax to the following:
```ruby
text_field behavior: :password
```