### PR TITLE
feat: Add support for _underline_ in markdown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ PATH
       dry-container (<= 0.8)
       dry-inflector (<= 0.1)
       ice_nine (~> 0.11)
-      redcarpet (~> 3.4)
+      redcarpet (~> 3.6)
       sinatra (>= 1.4, < 4.0)
       tzinfo (>= 1.1, < 3.0)
       tzinfo-data (~> 1.2018)

--- a/coprl.gemspec
+++ b/coprl.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sinatra', '>=1.4', '<4.0'
   spec.add_runtime_dependency 'tzinfo', '>=1.1', '< 3.0'
   spec.add_runtime_dependency 'tzinfo-data', '~>1.2018'
-  spec.add_runtime_dependency 'redcarpet', '~>3.4'
+  spec.add_runtime_dependency 'redcarpet', '~>3.6'
   spec.add_runtime_dependency 'zeitwerk', '~> 2.6'
 
   spec.add_development_dependency 'thor', '~> 1.1.0'

--- a/lib/coprl/presenters/web_client/helpers/markdown.rb
+++ b/lib/coprl/presenters/web_client/helpers/markdown.rb
@@ -2,7 +2,7 @@ module Coprl::Presenters::WebClient::Helpers
   module Markdown
     def base_markdown(text)
       unless @markdown
-        renderer = Coprl::Presenters::WebClient::CustomRender.new(hard_wrap: false, filter_html: true)
+        renderer = Coprl::Presenters::WebClient::CustomRender.new(hard_wrap: false, filter_html: true, underline: true)
         options = {
           autolink: false,
           no_intra_emphasis: true,
@@ -10,7 +10,8 @@ module Coprl::Presenters::WebClient::Helpers
           lax_html_blocks: true,
           strikethrough: true,
           superscript: true,
-          disable_indented_code_blocks: true
+          disable_indented_code_blocks: true,
+          underline: true
         }
         @markdown = Redcarpet::Markdown.new(renderer, options)
       end


### PR DESCRIPTION
Enables the "underline" extension in Redcarpet. Also upgrades Redcarpet from 3.4 to 3.6.