### PR TITLE
feat(file_input): Add support for content

### DIFF
--- a/lib/coprl/presenters/dsl/components/file_input.rb
+++ b/lib/coprl/presenters/dsl/components/file_input.rb
@@ -6,6 +6,7 @@ module Coprl
           include Mixins::Append
           include Mixins::Buttons
           include Mixins::Grids
+          include Mixins::Content
 
           attr_reader :accept, :preview, :components
 


### PR DESCRIPTION
`file_input` now permits `content` children instead of just `grid`.