### PR TITLE
Support icon in date/time fields

### DIFF
--- a/app/demo/components/date_fields.pom
+++ b/app/demo/components/date_fields.pom
@@ -25,8 +25,7 @@ Coprl::Presenters.define(:date_fields) do
     DOC
     grid do
       column 6 do
-        date_field name: :skydive_at,
-                       format: 'F j, Y' do
+        date_field name: :skydive_at, format: 'F j, Y', required: true do
           label 'Select your date to skydive'
           icon :event
           event :change do
@@ -41,7 +40,10 @@ Coprl::Presenters.define(:date_fields) do
     grid do
       column 6 do
         title 'Min Date'
-        date_field min_date: "2020-01-01"
+        date_field min_date: "2020-01-01" do
+          label 'Date on which to sky dive'
+          icon :event, position: :left
+        end
 
         title 'Max Date'
         date_field max_date: "2017-12-15"

--- a/lib/coprl/presenters/dsl/components/datetime_base.rb
+++ b/lib/coprl/presenters/dsl/components/datetime_base.rb
@@ -14,10 +14,14 @@ module Coprl
             merge_config(:mode)
             @picker = attribs_.delete(:picker){ true }
 
-            my_id = self.id
-            clear_icon(:clear) do
-              event :click do
-                clear my_id
+
+            unless required
+              my_id = self.id
+
+              clear_icon(:clear) do
+                event :click do
+                  clear my_id
+                end
               end
             end
           end
@@ -26,6 +30,14 @@ module Coprl
             return @clear_icon if locked?
             @clear_icon = icon ? Components::Icon.new(parent: self, icon: icon,
                                                       **attribs, &block) : nil
+          end
+
+          # overrides TextField#icon - need to default to left if this field is optional and has
+          # a "clear" icon.
+          def icon(icon=nil, **attribs, &block)
+            return @icon if locked?
+            icon_position = attribs.delete(:position) { @clear_icon ? :left : :right }
+            @icon = Components::Icon.new(parent: self, icon: icon, position: icon_position, **attribs, &block)
           end
 
           private

--- a/views/mdc/components/_datetime.erb
+++ b/views/mdc/components/_datetime.erb
@@ -1,13 +1,19 @@
 <%
   time_val = comp.value ? Array([comp.value]).join(', ') : nil
   type_class = comp.picker ? 'v-datetime' : 'v-date-text'
+  has_clear_icon = comp.picker && comp.clear_icon
+  has_leading_icon = comp.icon&.position&.include?(:left)
+  has_trailing_icon = comp.icon&.position&.include?(:right) || has_clear_icon
+  leading_icon = has_leading_icon ? comp.icon : nil
+  trailing_icon = (comp.icon&.position&.include?(:right) ? comp.icon : nil) || comp.picker && comp.clear_icon
 %>
 <div id="<%= comp.id %>"
      <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
      <% if comp.dirtyable %>data-dirtyable<% end %>
      class="v-input <%= type_class %> mdc-text-field mdc-text-field--outlined
             <%= 'v-focusable' if comp.focusable %>
-            <%= 'mdc-text-field--with-trailing-icon' if comp.clear_icon %>
+            <%= 'mdc-text-field--with-leading-icon' if has_leading_icon %>
+            <%= 'mdc-text-field--with-trailing-icon' if has_trailing_icon %>
             <%= 'mdc-text-field--disabled' if comp.disabled %>"
      data-config='<%= snake_to_camel(to_hash(comp.config), except: %i(time_24hr)).to_json %>'
      data-type='<%= comp.type %>'
@@ -24,7 +30,8 @@
          list="<%= comp.id %>-list"
          <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} if comp.events&.any? %>
          <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
-  <%= partial "components/icon", :locals => {comp: comp.clear_icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"}  if comp.picker && comp.clear_icon%>
+  <%= partial "components/icon", :locals => {comp: leading_icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"}  if has_leading_icon %>
+  <%= partial "components/icon", :locals => {comp: trailing_icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"}  if has_trailing_icon %>
   <%= partial "components/shared/input_label", :locals => {comp: comp} if comp %>
   <% if comp.picker %>
     <datalist id="<%= comp.id %>-list">


### PR DESCRIPTION
Adds support for leading and trailing icons in date/time fields. The field controls the default position of an icon (if no position is specified) depending on the presence of the "clear" button.