### PR TITLE
Fix `<select>` ID

### DIFF
--- a/views/mdc/components/_select.erb
+++ b/views/mdc/components/_select.erb
@@ -1,5 +1,6 @@
 <% float_label = comp.options.any?(&:selected) %>
-<div class="mdc-select v-select v-input
+<div id="<%= comp.id %>"
+     class="mdc-select v-select v-input
             <%= 'mdc-select--outlined' if comp.outlined %>
             <% if comp.disabled %>mdc-select--disabled<% end %>
             <% unless comp.label %>mdc-select--no-label<% end %>"


### PR DESCRIPTION
The web client's ERB template for the Select component was not including the component's ID in the DOM.