### PR TITLE
fix(chips): Fix chip set variants

### DIFF
--- a/app/demo/components/chips.pom
+++ b/app/demo/components/chips.pom
@@ -6,7 +6,12 @@ Coprl::Presenters.define(:chips) do
   attach :component_drawer
   page_title 'Chips'
 
+
   indented_grid do
+    content padding: :bottom do
+      text "Chips are always contained within a `chipset` component."
+    end
+
     chipset do
       chip 'Chip 1'
       chip 'Chip 1', color: :primary
@@ -15,6 +20,7 @@ Coprl::Presenters.define(:chips) do
         text 'Chip 3', color: :white
       end
     end
+
     subheading 'leading icon'
     chipset do
       chip 'Jane Smith', icon: :face
@@ -34,7 +40,13 @@ Coprl::Presenters.define(:chips) do
         icon :more_vert, position: :right
       end
     end
+
     heading 'Events'
+
+    text <<~TEXT
+      As with other components, chips support events. Additionally, a chip's leading icon, text,
+      and trailing icon all individually support their own events.
+    TEXT
 
     chipset do
       chip 'Jane Smith' do
@@ -93,11 +105,83 @@ Coprl::Presenters.define(:chips) do
       end
     end
 
-    title 'Chips as input', id: :input_chips
-    body 'You can set the name and value attributes of a chip, they then can be posted.
-          An example of this can be found in the [search select](/search_select) pattern demo.'
+    content padding: %i[top bottom] do
+      title '`filter` chipset'
+      text "Alright, who's in?"
 
+      chipset :filter do
+        ['Danny Ocean', 'Frank Catton', 'Robert "Rusty" Ryan', 'Tess Ocean'].each do |peep|
+          chip peep, selected: rand > 0.5 do
+            event :select do
+              snackbar "#{peep}'s in!"
+            end
+
+            event :deselect do
+              snackbar "#{peep}'s out."
+            end
+          end
+        end
+      end
+    end
+
+    content padding: %i[top bottom] do
+      title '`choice` chipset'
+      text 'At most one chip in a `choice` chipset can be selected.'
+
+      chipset :choice do
+        %w[Sun Mon Tue Wed Thu Fri Sat].each do |text|
+          chip text do
+            event :select do
+              snackbar "My favorite day is #{text}."
+            end
+
+            event :deselect do
+              snackbar "I have no favorite day."
+            end
+          end
+        end
+      end
+    end
+
+    form padding: %i[top bottom4] do
+      title '`input` chipset'
+      text '`input` chipsets convert typed tokens to chips. The chips can be removed by the user.'
+
+      chipset :input, name: 'values[]' do
+        label 'Fruits'
+
+        %w[Apple Orange Lime].each do |text|
+          chip text, value: text
+        end
+      end
+
+      content padding: %i[top bottom4] do
+        button 'Submit', type: :raised do
+          event :click do
+            replaces :submitted_chips, :submitted_chips
+          end
+        end
+      end
+    end
+
+    attach :submitted_chips
 
     attach :code, file: __FILE__
+  end
+end
+
+Coprl::Presenters.define(:submitted_chips) do
+  helpers do
+    def values
+      context.fetch(:values) { [] }
+    end
+  end
+
+  content id: :submitted_chips do
+    title 'Submitted chips' if values.any?
+
+    values.each do |value|
+      text "* #{value}"
+    end
   end
 end

--- a/lib/coprl/presenters/demo/dragon_drop.rb
+++ b/lib/coprl/presenters/demo/dragon_drop.rb
@@ -8,7 +8,7 @@ module Coprl
 
         configure do
           enable :sessions
-          set :session_secret, '0e53ba1da13aa8eb8cf3d361e67b70d79265edca'
+          set :session_secret, '0e53ba1da13aa8eb8cf3d361e67b70d79265edca0e53ba1da13aa8eb8cf3d361e67b70d79265edca'
         end
 
         post('/_dragon_drop_change_order_') do

--- a/lib/coprl/presenters/dsl/components/chip.rb
+++ b/lib/coprl/presenters/dsl/components/chip.rb
@@ -6,9 +6,8 @@ module Coprl
           include Mixins::Tooltips
           attr_reader :icons, :color, :name, :value, :chipset_variant, :selected
 
-          def initialize(**attribs_, &block)
-            super(type: :chip,
-                  **attribs_, &block)
+          def initialize(**attribs, &block)
+            super(type: :chip, **attribs, &block)
             @icons = []
             self.text(attribs.delete(:text)) if attribs.key?(:text)
             self.icon(attribs.delete(:icon)) if attribs.key?(:icon)
@@ -17,7 +16,12 @@ module Coprl
             @value = attribs.delete(:value)
             @selected = attribs.delete(:selected){false}
             expand!
-            @chipset_variant = self.parent(:chipset)&.variant.to_s
+            @chipset_variant = self.parent(:chipset)&.variant
+
+            if @chipset_variant == :input
+              @icons = @icons.delete_if { |i| i.position == :right }
+              icon(:cancel, position: :right)
+            end
           end
 
           def text(*text, **attribs, &block)
@@ -26,8 +30,7 @@ module Coprl
           end
 
           def icon(icon=nil, **attribs, &block)
-            @icons << Icon.new(parent: self, icon: icon,
-                               **attribs, &block)
+            @icons << Icon.new(parent: self, icon: icon, **attribs, &block)
           end
 
           def menu(**attributes, &block)
@@ -35,10 +38,21 @@ module Coprl
             @menu = Components::Menu.new(parent: self, **attributes, &block)
           end
 
-          class Icon < Components::IconBase
+          def choice?
+            chipset_variant == :choice
+          end
 
-            def initialize(**attribs_, &block)
-              super(**attribs_, &block)
+          def filter?
+            chipset_variant == :filter
+          end
+
+          def input?
+            chipset_variant == :input
+          end
+
+          class Icon < Components::IconBase
+            def initialize(**attribs, &block)
+              super(**attribs, &block)
               @position = [:left] if position.empty?
               expand!
             end

--- a/lib/coprl/presenters/dsl/components/chipset.rb
+++ b/lib/coprl/presenters/dsl/components/chipset.rb
@@ -4,28 +4,62 @@ module Coprl
       module Components
         class Chipset < Base
           include Mixins::Chips
-          attr_reader :variant, :components
+          attr_reader :variant, :components, :label, :name, :input_text_field
 
-          VALID_VARIANTS = %i[choice filter input].freeze
+          VARIANTS = %i[choice filter input static].freeze
 
-          def initialize(chipset_variant = nil, **attribs_, &block)
-            super(type: :chipset, **attribs_, &block)
-            @variant = validate_variant(chipset_variant)
+          def initialize(variant = :static, **attribs, &block)
+            super(type: :chipset, **attribs, &block)
+            @variant = validate_variant(variant)
+            @name = attribs.delete(:name)
             @components = []
+
             expand!
+
+            self_label = @label
+            @input_text_field = TextField.new(parent: self) do
+              label self_label if self_label
+            end
+
+            if input? && !name
+              logger.warn <<~TEXT
+                "\"input\" chip set #{id} is missing the `name` attribute. \
+                Its chips will not be included in form data.
+              TEXT
+            end
+          end
+
+          def label(text = nil)
+            return @label if locked?
+            @label = text
+          end
+
+          def choice?
+            variant == :choice
+          end
+
+          def filter?
+            variant == :filter
+          end
+
+          def input?
+            variant == :input
           end
 
           private
 
-          def validate_variant(chipset_variant)
-            return unless chipset_variant
-            chipset_variant = chipset_variant.to_sym
-            unless VALID_VARIANTS.include?(chipset_variant)
-              raise Errors::ParameterValidation, "Invalid chipset variant specified: #{chipset_variant}"
-            end
-            chipset_variant
-          end
+          def validate_variant(variant)
+            return :static unless variant
 
+            variant = variant.to_sym
+
+            unless VARIANTS.include?(variant)
+              list = VARIANTS.map(&:inspect).join(', ')
+              raise Errors::ParameterValidation, "Chipset variant must be one of #{list}"
+            end
+
+            variant
+          end
         end
       end
     end

--- a/lib/coprl/presenters/dsl/components/form.rb
+++ b/lib/coprl/presenters/dsl/components/form.rb
@@ -17,6 +17,7 @@ module Coprl
           include Mixins::FileInputs
           include Mixins::Images
           include Mixins::Tables
+          include Mixins::Chipset
 
           attr_reader :components, :shows_errors
 

--- a/lib/coprl/presenters/dsl/components/mixins/chipset.rb
+++ b/lib/coprl/presenters/dsl/components/mixins/chipset.rb
@@ -8,7 +8,7 @@ module Coprl
           module Chipset
             include Mixins::Append
 
-            def chipset(chipset_variant=nil, **attribs, &block)
+            def chipset(chipset_variant = :static, **attribs, &block)
               self << Components::Chipset.new(chipset_variant, parent: self, **attribs, &block)
             end
           end

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-u688aa917 {
+@keyframes mdc-checkbox-fade-in-background-u0cb0c968 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-u688aa917 {
+@keyframes mdc-checkbox-fade-out-background-u0cb0c968 {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u688aa917; }
+  animation-name: mdc-checkbox-fade-in-background-u0cb0c968; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u688aa917; }
+  animation-name: mdc-checkbox-fade-out-background-u0cb0c968; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -11659,16 +11659,48 @@ select {
 .mdc-chip-set--input .mdc-chip {
   animation: mdc-chip-entry 100ms cubic-bezier(0, 0, 0.2, 1); }
 
-button.mdc-chip {
-  border: none; }
+.v-chip-set.mdc-chip-set,
+.v-chip.mdc-chip,
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  gap: var(--v-padding1); }
 
-.mdc-chip__icon.v-icon-position-left {
-  float: none;
-  padding-right: 0; }
+.mdc-chip-set.mdc-chip-set--input {
+  padding: 0; }
 
-.mdc-chip__icon.v-icon-position-right {
-  float: none;
-  padding-left: 0; }
+.v-chip.mdc-chip-set,
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  flex-wrap: wrap;
+  align-items: center;
+  align-content: center; }
+
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  height: auto;
+  min-height: 56px;
+  padding: 12px 16px 14px; }
+
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field__input {
+  padding: 0;
+  flex: 1;
+  min-width: 10ch;
+  height: auto;
+  min-height: 32px; }
+
+.mdc-chip-set.mdc-chip-set--input .v-chip:last-of-type {
+  margin-right: var(--v-padding2); }
+
+.v-chip.mdc-chip {
+  line-height: revert; }
+
+.mdc-chip-set .v-chip.mdc-chip {
+  margin: 0; }
+
+.mdc-chip__text {
+  overflow: hidden;
+  text-overflow: ellipsis; }
+
+.v-icon.mdc-chip__icon {
+  position: revert;
+  padding: 0; }
 
 .v-chip__primary {
   background-color: #5488b2; }
@@ -14346,7 +14378,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-uc1d87bb5 {
+@keyframes mdc-checkbox-fade-in-background-ue8813a69 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -14358,7 +14390,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-uc1d87bb5 {
+@keyframes mdc-checkbox-fade-out-background-ue8813a69 {
   0%,
   80% {
     border-color: #5488b2;
@@ -14374,12 +14406,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-uc1d87bb5; }
+  animation-name: mdc-checkbox-fade-in-background-ue8813a69; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-uc1d87bb5; }
+  animation-name: mdc-checkbox-fade-out-background-ue8813a69; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }
@@ -15014,7 +15046,7 @@ button.mdc-chip {
 .flatpickr-calendar .hasWeeks .dayContainer {
   border-left: 0; }
 
-.flatpickr-calendar.showTimeInput.hasTime .flatpickr-time {
+.flatpickr-calendar.hasTime .flatpickr-time {
   height: 40px;
   border-top: 1px solid #e6e6e6; }
 
@@ -15031,9 +15063,13 @@ button.mdc-chip {
   width: 0;
   left: 22px; }
 
-.flatpickr-calendar.rightMost:before, .flatpickr-calendar.rightMost:after {
+.flatpickr-calendar.rightMost:before, .flatpickr-calendar.arrowRight:before, .flatpickr-calendar.rightMost:after, .flatpickr-calendar.arrowRight:after {
   left: auto;
   right: 22px; }
+
+.flatpickr-calendar.arrowCenter:before, .flatpickr-calendar.arrowCenter:after {
+  left: 50%;
+  right: 50%; }
 
 .flatpickr-calendar:before {
   border-width: 5px;
@@ -15093,6 +15129,10 @@ button.mdc-chip {
   flex: 1; }
 
 .flatpickr-months .flatpickr-prev-month, .flatpickr-months .flatpickr-next-month {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   text-decoration: none;
   cursor: pointer;
   position: absolute;
@@ -15112,9 +15152,7 @@ button.mdc-chip {
 .flatpickr-months .flatpickr-prev-month.flatpickr-prev-month, .flatpickr-months .flatpickr-next-month.flatpickr-prev-month {
   /*
       /*rtl:begin:ignore*/
-  left: 0;
-  /*
-      /*rtl:end:ignore*/ }
+  left: 0; }
 
 /*
       /*rtl:begin:ignore*/
@@ -15123,9 +15161,7 @@ button.mdc-chip {
 .flatpickr-months .flatpickr-prev-month.flatpickr-next-month, .flatpickr-months .flatpickr-next-month.flatpickr-next-month {
   /*
       /*rtl:begin:ignore*/
-  right: 0;
-  /*
-      /*rtl:end:ignore*/ }
+  right: 0; }
 
 /*
       /*rtl:begin:ignore*/
@@ -17422,6 +17458,9 @@ i:focus.v-datetime--clear {
     --v-padding3: 16px;
     --v-padding4: 24px;
     --v-padding5: 32px; } }
+
+*, *:before, *:after {
+  box-sizing: border-box; }
 
 .v-actionable {
   cursor: pointer; }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -52375,7 +52375,10 @@ var MDCSelect = /** @class */function (_super) {
 "use strict";
 /* unused harmony export EVENT_SELECT */
 /* unused harmony export EVENT_DESELECT */
-/* unused harmony export EVENT_TRAILING_ICON_CLICK */
+/* unused harmony export VARIANT_CHOICE */
+/* unused harmony export VARIANT_FILTER */
+/* unused harmony export VARIANT_INPUT */
+/* unused harmony export VARIANT_STATIC */
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
@@ -52395,29 +52398,48 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+// https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips
+
 var EVENT_SELECT = 'select';
 var EVENT_DESELECT = 'deselect';
-var EVENT_TRAILING_ICON_CLICK = 'trailing_icon_click';
 
-var SELECTABLE_VARIANT_CLASS = 'v-chip-set--selectable-variant';
-var CHIP_BEHAVIOR_AUTO_REMOVE = 'auto_remove';
-var CHIP_BEHAVIOR_NO_AUTO_REMOVE = 'no_auto_remove';
+var VARIANT_CHOICE = 'choice';
+var VARIANT_FILTER = 'filter';
+var VARIANT_INPUT = 'input';
+var VARIANT_STATIC = 'static';
 
-function initChips(e) {
+// event.keyCode constants
+var KEYS = {
+    backspace: 8,
+    delete: 46,
+    leftArrow: 37,
+    rightArrow: 39,
+    comma: 188,
+    enter: 13,
+    space: 32,
+    IMESequence: 229
+};
+
+function initChips(root) {
     console.debug('\tChips');
 
-    // The chip set > chips hierarchy is established differently than other
-    // components: a chip set constructs and manages Chip components for its
-    // chip elements.
-    //
-    // Because the chip set constructs chips on its own, a `hookupComponents`
-    // call for chips is not needed.
+    // The chip set > chip hierarchy is established differently than other
+    // components: a chip set constructs and manages MDCChip components for its
+    // child elements. Because of this, a `hookupComponents` call for .v-chip is
+    // not needed.
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(root, '.v-chip-set', function (element) {
+        var mdcChipSet = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["b" /* MDCChipSet */](element, undefined, function (element) {
+            var mdcChip = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["a" /* MDCChip */](element);
 
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
-        var chipFactory = CoprlChipFactoryFactory(CHIP_BEHAVIOR_NO_AUTO_REMOVE);
-        var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["b" /* MDCChipSet */](element, undefined, chipFactory);
+            // value is unused, but the constructor has side effects.
+            new VChip(element, mdcChip);
 
-        return new VChipSet(element, mdcComponent);
+            // the MDC chip set expects to manage instances of MDCChip, not
+            // VChip, so the chip factory must produce MDC chips.
+            return mdcChip;
+        });
+
+        return new VChipSet(element, mdcChipSet);
     });
 }
 
@@ -52429,26 +52451,40 @@ var VChip = function (_eventHandlerMixin) {
 
         var _this = _possibleConstructorReturn(this, (VChip.__proto__ || Object.getPrototypeOf(VChip)).call(this, element, mdcComponent));
 
-        _this.element.addEventListener('click', function (e) {
-            if (_this.selectable) {
-                _this.mdcComponent.selected = !_this.mdcComponent.selected;
-
-                var eventType = _this.mdcComponent.selected ? EVENT_SELECT : EVENT_DESELECT;
-                var selectionEvent = new Event(eventType, { bubbles: false });
-
-                _this.element.dispatchEvent(selectionEvent);
-            }
+        _this.mdcComponent.listen('MDCChip:selection', function (event) {
+            _this.element.dispatchEvent(new Event(event.detail.selected ? EVENT_SELECT : EVENT_DESELECT));
         });
+
+        mdcComponent.shouldRemoveOnTrailingIconClick = _this.variant == VARIANT_INPUT;
+
+        if (_this.variant == VARIANT_INPUT) {
+            // Store the `name` attribute so we can use it when generating new chips:
+            _this.element.dataset.name = _this.element.dataset.name || _this.chipSet.dataset.name;
+
+            _this.mdcComponent.listen('keydown', function (event) {
+                switch (event.keyCode) {
+                    case KEYS.backspace:
+                    case KEYS.delete:
+                        _this.chipSet.vComponent.focusTextField();
+                        _this.chipSet.vComponent.removeChip(_this.element);
+                        break;
+                    case KEYS.leftArrow:
+                    case KEYS.rightArrow:
+                        event.preventDefault();
+                        break;
+                }
+            });
+        }
         return _this;
     }
 
+    // Called to collect data for submission
+
+
     _createClass(VChip, [{
         key: 'prepareSubmit',
-
-
-        // Called to collect data for submission
         value: function prepareSubmit(params) {
-            if (this.shouldSubmitParams()) {
+            if (this.shouldSubmitParams) {
                 params.push([this.name(), this.value()]);
             }
         }
@@ -52474,39 +52510,30 @@ var VChip = function (_eventHandlerMixin) {
         }
     }, {
         key: 'shouldSubmitParams',
-        value: function shouldSubmitParams() {
+        get: function get() {
             // Selectable chips (those within a :filter or :choice chipset) which
             // are not currently selected do not submit their value.
             return this.name() && this.value() && (!this.selectable || this.mdcComponent.selected);
         }
     }, {
-        key: 'trailingIcon',
+        key: 'chipSet',
         get: function get() {
-            return this.element.querySelector('.mdc-chip__icon.mdc-chip__icon--trailing');
+            return this.element.closest('.v-chip-set');
+        }
+    }, {
+        key: 'variant',
+        get: function get() {
+            return this.chipSet.dataset.variant;
         }
     }, {
         key: 'selectable',
         get: function get() {
-            return this.element.parentElement.classList.contains(SELECTABLE_VARIANT_CLASS);
+            return this.variant == VARIANT_CHOICE || this.variant == VARIANT_FILTER;
         }
     }]);
 
     return VChip;
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
-
-// Returns a function which constructs VChip components.
-function CoprlChipFactoryFactory() {
-    var behavior = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : CHIP_BEHAVIOR_AUTO_REMOVE;
-
-    var autoRemove = behavior === CHIP_BEHAVIOR_AUTO_REMOVE;
-
-    return function (element) {
-        var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["a" /* MDCChip */](element);
-        mdcComponent.shouldRemoveOnTrailingIconClick = autoRemove;
-
-        return new VChip(element, mdcComponent);
-    };
-}
 
 var VChipSet = function (_eventHandlerMixin2) {
     _inherits(VChipSet, _eventHandlerMixin2);
@@ -52514,8 +52541,223 @@ var VChipSet = function (_eventHandlerMixin2) {
     function VChipSet(element, mdcComponent) {
         _classCallCheck(this, VChipSet);
 
-        return _possibleConstructorReturn(this, (VChipSet.__proto__ || Object.getPrototypeOf(VChipSet)).call(this, element, mdcComponent));
+        var _this2 = _possibleConstructorReturn(this, (VChipSet.__proto__ || Object.getPrototypeOf(VChipSet)).call(this, element, mdcComponent));
+
+        _this2.mdcComponent.listen('MDCChip:removal', function (event) {
+            _this2.removeChip(event.target);
+        });
+
+        // handle moving amongst sibling chips:
+        _this2.mdcComponent.listen('keydown', function (event) {
+            switch (event.keyCode) {
+                case KEYS.leftArrow:
+                    {
+                        if (!event.target.matches('.v-chip')) {
+                            return;
+                        }
+
+                        var previousSibling = event.target.previousElementSibling;
+
+                        if (previousSibling && previousSibling.matches('.v-chip')) {
+                            previousSibling.focus();
+                        }
+                        break;
+                    }
+                case KEYS.rightArrow:
+                    {
+                        var nextSibling = event.target.nextElementSibling;
+
+                        if (nextSibling && nextSibling.matches('.v-chip, .mdc-chip-set--input input')) {
+                            nextSibling.focus();
+                        }
+                        break;
+                    }
+            }
+        });
+
+        if (_this2.variant == VARIANT_INPUT) {
+            _this2.textField = _this2.element.querySelector('.v-text-field');
+            _this2.input = _this2.textField.querySelector('input');
+
+            _this2.textField.addEventListener('focusout', function (event) {
+                // remain visually focused if the new focused element is within the chip set:
+                if (event.relatedTarget && event.relatedTarget.closest('.v-chip-set') == _this2.element) {
+                    _this2.textField.classList.add('mdc-text-field--focused');
+                } else {
+                    _this2.textField.classList.remove('mdc-text-field--focused');
+                }
+
+                // keep the label floating if there are any chips in the chip set or text in the input field:
+                if (_this2.chips.length > 0 || _this2.input.value.length > 0) {
+                    _this2.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                    _this2.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+                } else {
+                    _this2.textField.vComponent.mdcComponent.foundation_.notchOutline(false);
+                    _this2.textField.vComponent.label.classList.remove('mdc-floating-label--float-above');
+                }
+            });
+
+            // TODO: internationalization: determine and use locale list separator character(s). see `Intl.ListFormat`?
+            // TODO: all of this is likely better handled by the `input` event.
+            _this2.textField.addEventListener('keydown', function (event) {
+                if (event.isComposing || event.keyCode == KEYS.IMESequence) {
+                    // user is composing a single character via multiple key
+                    // strokes – ignore input until they're done.
+                    return;
+                }
+
+                switch (event.keyCode) {
+                    case KEYS.enter:
+                        event.preventDefault(); // prevent submitting form
+                    // fallthrough
+                    case KEYS.comma:
+                    case KEYS.space:
+                        {
+                            var text = _this2.textField.vComponent.value().trim();
+
+                            if (!text || text.length < 1) {
+                                return;
+                            }
+
+                            _this2.addChip(_this2.makeInputChip(text));
+                            _this2.textField.vComponent.clear();
+                            break;
+                        }
+                    case KEYS.backspace:
+                    case KEYS.leftArrow:
+                        {
+                            if (document.activeElement != _this2.textField.querySelector('input')) {
+                                return;
+                            }
+
+                            // select the last chip if we're at the start of the text:
+                            var start = _this2.input.selectionStart;
+                            var length = Math.abs(_this2.input.selectionEnd - _this2.input.selectionStart);
+
+                            if (start == 0 && length < 1) {
+                                if (_this2.lastChip) {
+                                    _this2.lastChip.focus();
+                                }
+                            }
+
+                            break;
+                        }
+                    default:
+                        break;
+                }
+            });
+
+            if (_this2.chips.length > 0) {
+                _this2.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                _this2.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+
+                var _iteratorNormalCompletion = true;
+                var _didIteratorError = false;
+                var _iteratorError = undefined;
+
+                try {
+                    for (var _iterator = _this2.chips[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                        var chip = _step.value;
+
+                        _this2.input.insertAdjacentElement('beforebegin', chip);
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+                    } finally {
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
+                }
+            }
+
+            // when focusing a chip, the owning chip set should appear focused:
+            _this2.element.addEventListener('focusin', function (event) {
+                _this2.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                _this2.textField.classList.add('mdc-text-field--focused');
+                _this2.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+            });
+
+            // when focus moves outside of the chip set, the owning chip set should appear to have lost focus:
+            _this2.element.addEventListener('focusout', function (event) {
+                if (!event.relatedTarget || event.relatedTarget.closest('.v-chip-set') != _this2.element) {
+                    _this2.textField.classList.remove('mdc-text-field--focused');
+                }
+            });
+        }
+        return _this2;
     }
+
+    _createClass(VChipSet, [{
+        key: 'addChip',
+        value: function addChip(element) {
+            // https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips#adding-chips-to-the-dom
+            if (this.lastChip) {
+                this.lastChip.insertAdjacentElement('afterend', element);
+            } else {
+                this.textField.insertAdjacentElement('afterbegin', element);
+            }
+
+            // `MDCChipSet.addChip` runs its chip factory (see above, `initChips`),
+            // which creates an MDCChip and a VChip.
+            this.mdcComponent.addChip(element);
+        }
+    }, {
+        key: 'removeChip',
+        value: function removeChip(element) {
+            // https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips#removing-chips-from-the-dom
+            // most of a chip's removal is handled by MDC, but removing the DOM node
+            // is left to us.
+            element.remove();
+            this.focusTextField();
+        }
+    }, {
+        key: 'focusTextField',
+        value: function focusTextField() {
+            if (!this.textField) {
+                return;
+            }
+
+            this.textField.vComponent.focus();
+        }
+    }, {
+        key: 'makeInputChip',
+        value: function makeInputChip(text) {
+            var value = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : text;
+
+            // don't put ${text} or ${value} in this template literal. without escaping, it's vulnerable to XSS.
+            var html = '\n            <button type="button" class="v-chip v-input mdc-chip v-component" tabindex="0">\n                <div class="v-typography mdc-typography--chip-text mdc-chip__text v-component"></div>\n                <i class="v-icon mdc-chip__icon mdc-chip__icon--trailing material-icons">cancel</i>\n            </button>\n        ';
+            var template = document.createElement('template');
+            template.innerHTML = html.trim();
+
+            var element = template.content.firstChild;
+            element.dataset.value = value;
+            element.querySelector('.v-typography').textContent = text;
+
+            return element;
+        }
+    }, {
+        key: 'chips',
+        get: function get() {
+            return this.element.querySelectorAll('.v-chip');
+        }
+    }, {
+        key: 'variant',
+        get: function get() {
+            return this.element.dataset.variant;
+        }
+    }, {
+        key: 'lastChip',
+        get: function get() {
+            return this.textField.querySelector('.v-chip:last-of-type');
+        }
+    }]);
 
     return VChipSet;
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));

--- a/views/mdc/assets/js/components/chips.js
+++ b/views/mdc/assets/js/components/chips.js
@@ -3,29 +3,48 @@ import {MDCChipSet} from '@material/chips';
 import {eventHandlerMixin} from './mixins/event-handler';
 import {VBaseComponent, hookupComponentsManually} from './base-component';
 
+// https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips
+
 export const EVENT_SELECT = 'select';
 export const EVENT_DESELECT = 'deselect';
-export const EVENT_TRAILING_ICON_CLICK = 'trailing_icon_click';
 
-const SELECTABLE_VARIANT_CLASS = 'v-chip-set--selectable-variant';
-const CHIP_BEHAVIOR_AUTO_REMOVE = 'auto_remove';
-const CHIP_BEHAVIOR_NO_AUTO_REMOVE = 'no_auto_remove';
+export const VARIANT_CHOICE = 'choice';
+export const VARIANT_FILTER = 'filter';
+export const VARIANT_INPUT = 'input';
+export const VARIANT_STATIC = 'static';
 
-export function initChips(e) {
+// event.keyCode constants
+const KEYS = {
+    backspace: 8,
+    delete: 46,
+    leftArrow: 37,
+    rightArrow: 39,
+    comma: 188,
+    enter: 13,
+    space: 32,
+    IMESequence: 229,
+};
+
+export function initChips(root) {
     console.debug('\tChips');
 
-    // The chip set > chips hierarchy is established differently than other
-    // components: a chip set constructs and manages Chip components for its
-    // chip elements.
-    //
-    // Because the chip set constructs chips on its own, a `hookupComponents`
-    // call for chips is not needed.
+    // The chip set > chip hierarchy is established differently than other
+    // components: a chip set constructs and manages MDCChip components for its
+    // child elements. Because of this, a `hookupComponents` call for .v-chip is
+    // not needed.
+    hookupComponentsManually(root, '.v-chip-set', function(element) {
+        const mdcChipSet = new MDCChipSet(element, undefined, (element) => {
+            const mdcChip = new MDCChip(element);
 
-    hookupComponentsManually(e, '.v-chip-set', function(element) {
-        const chipFactory = CoprlChipFactoryFactory(CHIP_BEHAVIOR_NO_AUTO_REMOVE);
-        const mdcComponent = new MDCChipSet(element, undefined, chipFactory);
+            // value is unused, but the constructor has side effects.
+            new VChip(element, mdcChip);
 
-        return new VChipSet(element, mdcComponent);
+            // the MDC chip set expects to manage instances of MDCChip, not
+            // VChip, so the chip factory must produce MDC chips.
+            return mdcChip;
+        });
+
+        return new VChipSet(element, mdcChipSet);
     });
 }
 
@@ -33,29 +52,35 @@ export class VChip extends eventHandlerMixin(VBaseComponent) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
 
-        this.element.addEventListener('click', (e) => {
-            if (this.selectable) {
-                this.mdcComponent.selected = !this.mdcComponent.selected;
-
-                const eventType = this.mdcComponent.selected
-                    ? EVENT_SELECT
-                    : EVENT_DESELECT;
-                const selectionEvent = new Event(eventType, {bubbles: false});
-
-                this.element.dispatchEvent(selectionEvent);
-            }
+        this.mdcComponent.listen('MDCChip:selection', (event) => {
+            this.element.dispatchEvent(new Event(event.detail.selected ? EVENT_SELECT : EVENT_DESELECT));
         });
-    }
 
-    get trailingIcon() {
-        return this.element.querySelector(
-            '.mdc-chip__icon.mdc-chip__icon--trailing'
-        );
+        mdcComponent.shouldRemoveOnTrailingIconClick = this.variant == VARIANT_INPUT;
+
+        if (this.variant == VARIANT_INPUT) {
+            // Store the `name` attribute so we can use it when generating new chips:
+            this.element.dataset.name = this.element.dataset.name || this.chipSet.dataset.name;
+
+            this.mdcComponent.listen('keydown', (event) => {
+                switch (event.keyCode) {
+                case KEYS.backspace:
+                case KEYS.delete:
+                    this.chipSet.vComponent.focusTextField();
+                    this.chipSet.vComponent.removeChip(this.element);
+                    break;
+                case KEYS.leftArrow:
+                case KEYS.rightArrow:
+                    event.preventDefault();
+                    break;
+                }
+            });
+        }
     }
 
     // Called to collect data for submission
     prepareSubmit(params) {
-        if (this.shouldSubmitParams()) {
+        if (this.shouldSubmitParams) {
             params.push([this.name(), this.value()]);
         }
     }
@@ -76,34 +101,214 @@ export class VChip extends eventHandlerMixin(VBaseComponent) {
         this.element.setAttribute('data-value', value);
     }
 
-    shouldSubmitParams() {
+    get shouldSubmitParams() {
         // Selectable chips (those within a :filter or :choice chipset) which
         // are not currently selected do not submit their value.
         return this.name() && this.value()
             && (!this.selectable || this.mdcComponent.selected);
     }
 
-    get selectable() {
-        return this.element.parentElement.classList.contains(
-            SELECTABLE_VARIANT_CLASS
-        );
+    get chipSet() {
+        return this.element.closest('.v-chip-set');
     }
-}
 
-// Returns a function which constructs VChip components.
-function CoprlChipFactoryFactory(behavior = CHIP_BEHAVIOR_AUTO_REMOVE) {
-    const autoRemove = behavior === CHIP_BEHAVIOR_AUTO_REMOVE;
+    get variant() {
+        return this.chipSet.dataset.variant;
+    }
 
-    return function(element) {
-        const mdcComponent = new MDCChip(element);
-        mdcComponent.shouldRemoveOnTrailingIconClick = autoRemove;
-
-        return new VChip(element, mdcComponent);
-    };
+    get selectable() {
+        return this.variant == VARIANT_CHOICE || this.variant == VARIANT_FILTER;
+    }
 }
 
 export class VChipSet extends eventHandlerMixin(VBaseComponent) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
+
+        this.mdcComponent.listen('MDCChip:removal', (event) => {
+            this.removeChip(event.target);
+        });
+
+        // handle moving amongst sibling chips:
+        this.mdcComponent.listen('keydown', (event) => {
+            switch (event.keyCode) {
+            case KEYS.leftArrow: {
+                if (!event.target.matches('.v-chip')) {
+                    return;
+                }
+
+                const previousSibling = event.target.previousElementSibling;
+
+                if (previousSibling && previousSibling.matches('.v-chip')) {
+                    previousSibling.focus();
+                }
+                break;
+            }
+            case KEYS.rightArrow: {
+                const nextSibling = event.target.nextElementSibling;
+
+                if (nextSibling && nextSibling.matches('.v-chip, .mdc-chip-set--input input')) {
+                    nextSibling.focus();
+                }
+                break;
+            }
+            }
+        });
+
+        if (this.variant == VARIANT_INPUT) {
+            this.textField = this.element.querySelector('.v-text-field');
+            this.input = this.textField.querySelector('input');
+
+            this.textField.addEventListener('focusout', (event) => {
+                // remain visually focused if the new focused element is within the chip set:
+                if (event.relatedTarget && event.relatedTarget.closest('.v-chip-set') == this.element) {
+                    this.textField.classList.add('mdc-text-field--focused');
+                }
+                else {
+                    this.textField.classList.remove('mdc-text-field--focused');
+                }
+
+                // keep the label floating if there are any chips in the chip set or text in the input field:
+                if (this.chips.length > 0 || this.input.value.length > 0) {
+                    this.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                    this.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+                }
+                else {
+                    this.textField.vComponent.mdcComponent.foundation_.notchOutline(false);
+                    this.textField.vComponent.label.classList.remove('mdc-floating-label--float-above');
+                }
+            });
+
+            // TODO: internationalization: determine and use locale list separator character(s). see `Intl.ListFormat`?
+            // TODO: all of this is likely better handled by the `input` event.
+            this.textField.addEventListener('keydown', (event) => {
+                if (event.isComposing || event.keyCode == KEYS.IMESequence) {
+                    // user is composing a single character via multiple key
+                    // strokes – ignore input until they're done.
+                    return;
+                }
+
+                switch (event.keyCode) {
+                case KEYS.enter:
+                    event.preventDefault(); // prevent submitting form
+                    // fallthrough
+                case KEYS.comma:
+                case KEYS.space: {
+                    const text = this.textField.vComponent.value().trim();
+
+                    if (!text || text.length < 1) {
+                        return;
+                    }
+
+                    this.addChip(this.makeInputChip(text));
+                    this.textField.vComponent.clear();
+                    break;
+                }
+                case KEYS.backspace:
+                case KEYS.leftArrow: {
+                    if (document.activeElement != this.textField.querySelector('input')) {
+                        return;
+                    }
+
+                    // select the last chip if we're at the start of the text:
+                    const start = this.input.selectionStart;
+                    const length = Math.abs(this.input.selectionEnd - this.input.selectionStart);
+
+                    if (start == 0 && length < 1) {
+                        if (this.lastChip) {
+                            this.lastChip.focus();
+                        }
+                    }
+
+                    break;
+                }
+                default:
+                    break;
+                }
+            });
+
+            if (this.chips.length > 0) {
+                this.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                this.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+
+                for (const chip of this.chips) {
+                    this.input.insertAdjacentElement('beforebegin', chip);
+                }
+            }
+
+            // when focusing a chip, the owning chip set should appear focused:
+            this.element.addEventListener('focusin', (event) => {
+                this.textField.vComponent.mdcComponent.foundation_.notchOutline(true);
+                this.textField.classList.add('mdc-text-field--focused');
+                this.textField.vComponent.label.classList.add('mdc-floating-label--float-above');
+            });
+
+            // when focus moves outside of the chip set, the owning chip set should appear to have lost focus:
+            this.element.addEventListener('focusout', (event) => {
+                if (!event.relatedTarget || event.relatedTarget.closest('.v-chip-set') != this.element) {
+                    this.textField.classList.remove('mdc-text-field--focused');
+                }
+            });
+        }
+    }
+
+    get chips() {
+        return this.element.querySelectorAll('.v-chip');
+    }
+
+    get variant() {
+        return this.element.dataset.variant;
+    }
+
+    get lastChip() {
+        return this.textField.querySelector('.v-chip:last-of-type');
+    }
+
+    addChip(element) {
+        // https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips#adding-chips-to-the-dom
+        if (this.lastChip) {
+            this.lastChip.insertAdjacentElement('afterend', element);
+        }
+        else {
+            this.textField.insertAdjacentElement('afterbegin', element);
+        }
+
+        // `MDCChipSet.addChip` runs its chip factory (see above, `initChips`),
+        // which creates an MDCChip and a VChip.
+        this.mdcComponent.addChip(element);
+    }
+
+    removeChip(element) {
+        // https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips#removing-chips-from-the-dom
+        // most of a chip's removal is handled by MDC, but removing the DOM node
+        // is left to us.
+        element.remove();
+        this.focusTextField();
+    }
+
+    focusTextField() {
+        if (!this.textField) {
+            return;
+        }
+
+        this.textField.vComponent.focus();
+    }
+
+    makeInputChip(text, value = text) {
+        // don't put ${text} or ${value} in this template literal. without escaping, it's vulnerable to XSS.
+        const html = `
+            <button type="button" class="v-chip v-input mdc-chip v-component" tabindex="0">
+                <div class="v-typography mdc-typography--chip-text mdc-chip__text v-component"></div>
+                <i class="v-icon mdc-chip__icon mdc-chip__icon--trailing material-icons">cancel</i>
+            </button>
+        `;
+        const template = document.createElement('template');
+        template.innerHTML = html.trim();
+
+        const element = template.content.firstChild;
+        element.dataset.value = value;
+        element.querySelector('.v-typography').textContent = text;
+
+        return element;
     }
 }

--- a/views/mdc/assets/scss/components/chip.scss
+++ b/views/mdc/assets/scss/components/chip.scss
@@ -1,27 +1,59 @@
 @import "@material/chips/mdc-chips";
 
-button.mdc-chip {
-  border: none;
+.v-chip-set.mdc-chip-set,
+.v-chip.mdc-chip,
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  gap: var(--v-padding1);
 }
 
-.mdc-chip__icon.v-icon-position-left {
-  float: none;
-  padding-right: 0;
+.mdc-chip-set.mdc-chip-set--input {
+  padding: 0;
 }
 
-.mdc-chip__icon.v-icon-position-top {
-  //position: absolute;
-  //top: 0;
+.v-chip.mdc-chip-set,
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  flex-wrap: wrap;
+  align-items: center;
+  align-content: center; // for flex-wrap
 }
 
-.mdc-chip__icon.v-icon-position-right {
-  float: none;
-  padding-left: 0;
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field {
+  // "input" chip sets can wrap to new lines, so the height must be flexible:
+  height: auto;
+  min-height: $mdc-text-field-height;
+
+  // for "input" chip sets, move mdc-text-field__input's padding up to the wrapper:
+  padding: 12px 16px 14px;
 }
 
-.mdc-chip__icon.v-icon-position-bottom {
-  //position: absolute;
-  //bottom: 0;
+.mdc-chip-set.mdc-chip-set--input .mdc-text-field__input {
+  padding: 0;
+  flex: 1;
+  min-width: 10ch;
+  height: auto;
+  min-height: $mdc-chip-height-default;
+}
+
+.mdc-chip-set.mdc-chip-set--input .v-chip:last-of-type {
+  margin-right: var(--v-padding2);
+}
+
+.v-chip.mdc-chip {
+  line-height: revert;
+}
+
+.mdc-chip-set .v-chip.mdc-chip {
+  margin: 0;
+}
+
+.mdc-chip__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v-icon.mdc-chip__icon {
+  position: revert;
+  padding: 0;
 }
 
 .v-chip__primary {

--- a/views/mdc/assets/scss/styles.scss
+++ b/views/mdc/assets/scss/styles.scss
@@ -1,5 +1,9 @@
 @import 'node_modules/@material/layout-grid/mixins';
 
+*, *:before, *:after {
+    box-sizing: border-box;
+}
+
 .v-actionable {
     cursor: pointer;
 }
@@ -71,4 +75,3 @@ button.v-button.mdc-dialog__button.v-hidden {
 .v-align-right {
     text-align: right;
 }
-

--- a/views/mdc/components/_chip.erb
+++ b/views/mdc/components/_chip.erb
@@ -1,57 +1,57 @@
 <%
-  if comp
-    leading_icon = comp.icons.select { |i| i.position.select { |p| eq(p, :left) }.any? }.first
-    trailing_icon = comp.icons.select { |i| i.position.select { |p| eq(p, :right) }.any? }.first
-    child_events = (leading_icon&.events || trailing_icon&.events || comp.text&.events || []).any?
+  leading_icon = comp.icons.select { |i| i.position.select { |p| eq(p, :left) }.any? }.first
+  trailing_icon = comp.icons.select { |i| i.position.select { |p| eq(p, :right) }.any? }.first
+  child_events = (leading_icon&.events || trailing_icon&.events || comp.text&.events || []).any?
 %>
-  <% if comp.menu %>
-    <div class="mdc-menu-anchor">
+<% if comp.menu %>
+  <div class="mdc-menu-anchor">
+<% end %>
+<button id="<%= comp.id %>"
+        type="button" <%# default button type is "submit", but chip clicks shouldn't submit a <form>. %>
+        <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
+        class="v-chip v-input mdc-chip
+            <%= color_classname(comp) %>
+            <%= 'mdc-chip--selected' if comp.selected %>
+            v-menu-click
+            <% if comp.draggable %>v-dnd-draggable<% end %>"
+        <% if child_events || comp.choice? || comp.filter? || comp.input? %>tabindex="0"<% end %>
+        <% if comp.name %>data-name="<%= comp.name %>"<% end %>
+        <% if comp.value %>data-value="<%= comp.value %>"<% end %>
+        style="<%= color_style(comp, 'background-') %>"
+        <%= draggable_attributes(comp) %>
+        <%= drop_zone_attributes(comp) %>
+        <%= partial("components/event", locals: {comp: comp,
+                                                 events: comp.events,
+                                                 parent_id: comp.id}) if comp.events&.any? %>
+        <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
+  <%# leading icon must come before the checkmark of a filter chip. the icon will replace the checkmark when the chip is selected. %>
+  <%# https://github.com/material-components/material-components-web/tree/v3.2.0/packages/mdc-chips#filter-chips %>
+  <% if leading_icon %>
+    <% hidden_icon_class = eq(comp.chipset_variant, :filter) && comp.selected ? 'mdc-chip__icon--leading-hidden' : '' %>
+    <%= partial("components/icon", locals: {comp: leading_icon,
+                                            class_name: "mdc-chip__icon mdc-chip__icon--leading #{hidden_icon_class}",
+                                            events: child_events ? (leading_icon&.events || comp.events) : nil}) %>
   <% end %>
-
-  <button id="<%= comp.id %>"
-          <% if comp.input_tag %>
-          data-input-tag="<%= comp.input_tag %>"
-          <% end %>
-          class="v-chip v-input mdc-chip
-              <%= color_classname(comp) %>
-              <%= 'mdc-chip--selected' if comp.selected %>
-              v-menu-click
-              <% if comp.draggable %>v-dnd-draggable
-            <% end %>"
-          <% if comp.name %>
-          data-name="<%= comp.name %>"
-          <% end %>
-          <% if comp.value %>
-          data-value="<%= comp.value %>"
-          <% end %>
-          style="<%= color_style(comp, 'background-') %>"
-          <%= draggable_attributes(comp) %>
-          <%= drop_zone_attributes(comp) %>
-          tabindex="0"
-          <%= partial("components/event", locals: {comp: comp,
-                                                events: comp.events,
-                                                parent_id: comp.id}) if comp.events&.any? %>
-          <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
-    <%= partial("components/icon", :locals => {comp: leading_icon,
-                                            class_name: 'mdc-chip__icon mdc-chip__icon--leading',
-                                            events: child_events ? (leading_icon&.events || comp.events) : nil}) if leading_icon %>
-    <% if comp.chipset_variant == 'filter' %>
+  <% if eq(comp.chipset_variant, :filter) %>
     <span class="mdc-chip__checkmark">
       <svg class="mdc-chip__checkmark-svg" viewBox="-2 -3 30 30">
-        <path class="mdc-chip__checkmark-path" fill="none" stroke="black"
-              d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+        <path class="mdc-chip__checkmark-path" fill="none" stroke="currentColor" d="M1.73,12.91 8.1,19.28 22.79,4.59" />
       </svg>
     </span>
-    <% end %>
-
-    <%= partial "components/typography", :locals => {comp: comp.text, type: 'chip-text', class_name: 'mdc-chip__text'} if comp.text  %>
-    <%= partial("components/icon", locals: {comp: trailing_icon,
-                                         class_name: 'mdc-chip__icon mdc-chip__icon--trailing',
-                                         events: child_events ? (trailing_icon&.events || comp.events) : nil}) if trailing_icon %>
-  </button>
-  <% if comp.menu %>
-    <%= partial "components/list/menu", :locals => {:comp => comp.menu} %>
-    </div>
   <% end %>
-  <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>
+
+  <%= partial "components/typography", :locals => {comp: comp.text, type: 'chip-text', class_name: 'mdc-chip__text'} if comp.text  %>
+
+  <%# Per the MDC-web Chip docs, "Trailing icons should only be added to input chips." %>
+  <%# But, Core is relying on non-input chip trailing icons. ¯\_(ツ)_/¯ %>
+  <% if trailing_icon %>
+    <%= partial("components/icon", locals: {comp: trailing_icon,
+                                            class_name: 'mdc-chip__icon mdc-chip__icon--trailing',
+                                            events: child_events ? (trailing_icon&.events || comp.events) : nil}) %>
+  <% end %>
+</button>
+<% if comp.menu %>
+  <%= partial "components/list/menu", :locals => {:comp => comp.menu} %>
+  </div> <%# end tag for mdc-menu-anchor, above %>
 <% end %>
+<%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>

--- a/views/mdc/components/_chipset.erb
+++ b/views/mdc/components/_chipset.erb
@@ -1,18 +1,19 @@
 <%
-  variant_classes = []
-  variant_classes << "mdc-chip-set--#{comp.variant}" if comp.variant
-  variant_classes << 'v-chip-set--selectable-variant' if eq(comp.variant, :select) || eq(comp.variant, :filter)
+  variant_class = "mdc-chip-set--#{comp.variant}"
 %>
 <div id="<%= comp.id %>"
-     class="v-chip-set mdc-chip-set
-            <%= variant_classes.join(' ') %>
-            <% if comp.draggable %>v-dnd-draggable
-       <% end %>"
+     class="v-chip-set mdc-chip-set <%= variant_class %> <% if comp.draggable %>v-dnd-draggable<% end %>"
+     data-variant="<%= comp.variant %>"
+     <% if comp.name %>data-name="<%= comp.name %>"<% end %>
      <%= draggable_attributes(comp) %>
      <%= drop_zone_attributes(comp) %>
-     <%= partial("components/event", locals: {comp: comp,
-                                           events: comp.events,
-                                           parent_id: comp.id}) if comp.events&.any? %>
+     <% if comp.events&.any? %>
+       <%= partial("components/event", locals: {comp: comp, events: comp.events, parent_id: comp.id}) %>
+     <% end %>
      <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
-  <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>
+  <%= partial "components/render", locals: {components: comp.components, scope: nil} %>
+  <% if comp.input? %>
+    <%# "input" chips are moved into and created within the text field's wrapper. (see js/components/chips.js) %>
+    <%= partial 'components/text_field', locals: {comp: comp.input_text_field} %>
+  <% end %>
 </div>

--- a/views/mdc/components/_icon.erb
+++ b/views/mdc/components/_icon.erb
@@ -20,13 +20,13 @@
      size_class = "v-icon-size-#{comp.size}" unless bound_locals_include?(:size_class, binding)
 %>
   <i id="<%= comp.id %>"
-     class="<%= class_name %> <%= icon_class_name %> <%= size_class %>
+     class="v-icon <%= class_name %> <%= icon_class_name %> <%= size_class %>
             <%= 'v-hidden' if comp.respond_to?(:hidden) && comp.hidden %>
-            <%= 'v-actionable' if comp.events %>
+            <%= 'v-actionable' if events&.any? %>
             <%= color_classname(comp) %>"
       <%= "data-#{data}" if data %>
       style="<%= color_style(comp) %>"
-      <%= 'tabindex="0"' if comp.events %>
+      <%= 'tabindex="0" role="button"' if events&.any? %>
       <%= partial "components/event", :locals => {comp: comp, events: events, parent_id: parent_id} if events&.any? %>
       <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <%= icon %>


### PR DESCRIPTION
None of the chip set variants really worked according to the MDC-web docs. Filter chips didn't support icons, and choice and input chip sets didn't do anything at all.

Filter chips continue to work mostly as they have been. Zero or many chips in a filter chip set can be selected. The leading icon of a selected filter chip is replaced with a check mark.

Choice chips now permit zero or one item to be selected. Selecting a different chip when one is already selected changes the selected chip, deselecting the original chip.

Input chips are essentially completely new to COPRL. An input chip set is wrapped in a text field and allows users to type words, which are then converted to chips. Users can remove existing chips via the trailing × "cancel" icon in the chips. Because of this, input chips do not support trailing icons. If an input chip has a trailing icon, it is replaced at render time with a × "cancel" icon.

Input chip sets will create new chips when the user presses enter, space, or inserts a comma. Currently, input chips do not support localization and may not work well on non-US English keyboard layouts.

By default, for backward compatibility, chip sets are considered "static." Chips within a static chip set have no special behavior and are effectively just pill-shaped containers.

As before, all chip set elements (leading icon, trailing icon, text, and body) continue to support COPRL events.