### PR TITLE
fix(button): Fix raised buttons in dialogs within forms

### DIFF
--- a/lib/coprl/presenters/dsl/components/button.rb
+++ b/lib/coprl/presenters/dsl/components/button.rb
@@ -26,7 +26,7 @@ module Coprl
             @position = Array(default_position).compact
             @disabled_on_post_finished = attribs.delete(:disabled_on_post_finished) {false}
             expand!
-            @event_parent_id = self.parent(:form)&.id || id
+            @event_parent_id = parent_form&.id || id
           end
 
           def icon(icon = nil, **attribs, &block)
@@ -44,7 +44,15 @@ module Coprl
             @menu = Components::Menu.new(parent: self, position: menu_position, **attributes, &block)
           end
 
+          def in_form?
+            parent_form != nil
+          end
+
           private
+
+          def parent_form
+            parent(:form)
+          end
 
           def default_position
             attribs.delete(:position){button_type == :fab ? %i(top right) : nil}

--- a/views/mdc/components/buttons/_button.erb
+++ b/views/mdc/components/buttons/_button.erb
@@ -2,24 +2,25 @@
    position_classes = comp.position.map {|p| "v-button-position-#{p}"}.join(' ')
    event_parent_id = nil unless bound_locals_include?(:event_parent_id, binding)
    data_attributes = '' unless bound_locals_include?(:data_attributes, binding)
+   button_type = eq(comp.button_type, :raised) && comp.in_form? ? :submit : :button
 %>
 <button id="<%= comp.id %>"
-         class="v-button v-button--button mdc-button <%=class_name%>
-         <%= 'v-hidden' if comp.hidden %>
-         <%= 'mdc-button--raised' if eq(comp.button_type, :raised) %>
-         <%= 'v-secondary-filled-button' if eq(comp.button_type, :raised) && eq(comp.color, :secondary) %>
-         <%= 'v-secondary-text-button' if eq(comp.button_type, :flat) && eq(comp.color, :secondary) %>
-         <%=  position_classes %>
-         <%= 'v-menu-click' if comp.menu%>
-         <%= 'v-nowrap' unless comp.wrap_text%>
-         <%= color_classname(comp, 'background-', :background_color)%>"
-         style="<%= color_style(comp) %> <%= color_style(comp, 'background-', :background_color) %>"
-         <%= data_attributes %>
+        type="<%= button_type %>"
+        class="v-button v-button--button mdc-button <%=class_name%>
+               <%= 'v-hidden' if comp.hidden %>
+               <%= 'mdc-button--raised' if eq(comp.button_type, :raised) %>
+               <%= 'v-secondary-filled-button' if eq(comp.button_type, :raised) && eq(comp.color, :secondary) %>
+               <%= 'v-secondary-text-button' if eq(comp.button_type, :flat) && eq(comp.color, :secondary) %>
+               <%=  position_classes %>
+               <%= 'v-menu-click' if comp.menu%>
+               <%= 'v-nowrap' unless comp.wrap_text%>
+               <%= color_classname(comp, 'background-', :background_color)%>"
+        style="<%= color_style(comp) %> <%= color_style(comp, 'background-', :background_color) %>"
+        <%= data_attributes %>
         data-disabled-on-post-finished="<%= comp.disabled_on_post_finished %>"
-<%= 'disabled ' if comp.disabled %>
-<%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
-<%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
-<%= partial 'components/shared/test_id', locals: {comp: comp} %>>
+    <% if comp.disabled %>disabled<% end %>
+    <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
+    <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-button__icon'} if comp.icon %>
   <%= partial "components/image", :locals => {comp: comp.image} if comp.image %>
   <%= comp.text %>


### PR DESCRIPTION
In the web client, when a dialog with a raised button is nested within a parent form (so: form > dialog > button), the button is rendered as `type="submit"`. This inadvertently attempts to submit the parent form instead of the dialog.

This fix causes raised buttons to be rendered as `type="submit'` only if they're in a form. Otherwise, they're rendered as `type="button"`.