### PR TITLE
feat: Add support for test IDs

### DIFF
--- a/lib/coprl/presenters/dsl/components/base.rb
+++ b/lib/coprl/presenters/dsl/components/base.rb
@@ -21,17 +21,19 @@ module Coprl
                       :attributes,
                       :draggable,
                       :drop_zone,
-                      :css_class
+                      :css_class,
+                      :test_id
 
           alias attribs attributes # unused in here, but used in descendents.
 
-          def initialize(type:, parent:, id: nil, tag: nil, input_tag: nil, **attributes, &block)
+          def initialize(type:, parent:, id: nil, tag: nil, input_tag: nil, test_id: nil, **attributes, &block)
             @draggable = attributes.delete(:draggable) {nil}
             @drop_zone = attributes.delete(:drop_zone) {nil}
             @css_class = Array(attributes.delete(:class) {nil})
             @id = id || generate_id
             @event_parent_id = @id
             @input_tag = input_tag || tag
+            @test_id = test_id
             @type = type
             @parent = parent
             @attributes = attributes

--- a/lib/coprl/presenters/settings.rb
+++ b/lib/coprl/presenters/settings.rb
@@ -32,6 +32,7 @@ unless defined?(Coprl::Presenters::Settings)
             setting :custom_css, '../public/presenters'
             setting :protect_from_forgery, false
             setting :asset_host, proc { |request| request.base_url }
+            setting :test_id_attribute, 'data-testid'
           end
           setting :plugins, []
           setting :components do

--- a/views/mdc/body/_dismissable-drawer.erb
+++ b/views/mdc/body/_dismissable-drawer.erb
@@ -2,7 +2,9 @@
   top_items = drawer.menu&.items&.select { |i| eq(i.position, :top) }
   bottom_items = drawer.menu&.items&.select { |i| eq(i.position, :bottom) }
 %> 
-<aside id="<%= drawer.id %>" class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__dismissible mdc-drawer mdc-drawer--dismissible mdc-drawer--open">
+<aside id="<%= drawer.id %>"
+       class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__dismissible mdc-drawer mdc-drawer--dismissible mdc-drawer--open"
+       <%= partial 'components/shared/test_id', locals: {comp: drawer} %>>
   <% if drawer.title || drawer.subtitle %>
     <div class="mdc-drawer__header">
   <% end %>

--- a/views/mdc/body/_header.erb
+++ b/views/mdc/body/_header.erb
@@ -10,7 +10,8 @@
         <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button">menu</button>
       <% end %>
       <span class="mdc-top-app-bar__title <%= 'v-actionable' if header.title&.events %>"
-            <%= partial "components/event", :locals => {comp: header, events: header.title&.events, parent_id: header.title&.event_parent_id} %>>
+            <%= partial "components/event", :locals => {comp: header, events: header.title&.events, parent_id: header.title&.event_parent_id} %>
+            <%= partial 'components/shared/test_id', locals: {comp: header} %>>
         <%= expand_text(header.title&.text, markdown: header.title&.markdown) %>
       </span>
     </section>

--- a/views/mdc/body/_modal-drawer.erb
+++ b/views/mdc/body/_modal-drawer.erb
@@ -2,7 +2,9 @@
   top_items = drawer.menu&.items&.select { |i| eq(i.position, :top) }
   bottom_items = drawer.menu&.items&.select { |i| eq(i.position, :bottom) }
 %>
-<aside id="<%= drawer.id %>" class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__modal mdc-drawer mdc-drawer--modal">
+<aside id="<%= drawer.id %>"
+       class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__modal mdc-drawer mdc-drawer--modal"
+       <%= partial 'components/shared/test_id', locals: {comp: drawer} %>>
   <% if drawer.title || drawer.subtitle %>
     <div class="mdc-drawer__header">
   <% end %>

--- a/views/mdc/components/_avatar.erb
+++ b/views/mdc/components/_avatar.erb
@@ -19,7 +19,8 @@
            class="v-avatar
                <%= 'v-actionable' if events %>"
          src="<%= comp.avatar %>"
-         <%= partial "components/event", :locals => {comp: comp, events: events, parent_id: comp.event_parent_id} if events&.any? %> />
+         <%= partial "components/event", :locals => {comp: comp, events: events, parent_id: comp.event_parent_id} if events&.any? %>
+         <%= partial 'components/shared/test_id', locals: {comp: comp} %> />
       <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>
     </span>
   <% else %>

--- a/views/mdc/components/_badge.erb
+++ b/views/mdc/components/_badge.erb
@@ -1,7 +1,11 @@
 <% if comp.icon %>
-  <div class="material-icons mdl-badge--overlap mdl-badge <%= comp.css_class.join(' ') %>" data-badge="<%= comp.badge %>">
+  <div class="material-icons mdl-badge--overlap mdl-badge <%= comp.css_class.join(' ') %>"
+       data-badge="<%= comp.badge %>"
+       <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <%= comp.icon %>
   </div>
 <% else %>
-  <span class="mdl-badge <%= comp.css_class.join(' ') %>" data-badge="<%= comp.badge %>"><%=expand_text(comp.text)%></span>
+  <span class="mdl-badge <%= comp.css_class.join(' ') %>"
+        data-badge="<%= comp.badge %>"
+        <%= partial 'components/shared/test_id', locals: {comp: comp} %>><%= expand_text(comp.text) %></span>
 <% end %>

--- a/views/mdc/components/_card.erb
+++ b/views/mdc/components/_card.erb
@@ -15,6 +15,7 @@
     <%= "height: #{comp.height};" if comp.height %>
     <%= color_style(comp, 'background-', :background_color) %>"
   <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp %>
+  <%= partial 'components/shared/test_id', locals: {comp: comp} %>
   data-is-container>
     <%= partial("components/progress", :locals => {:comp => comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(top both)) %>
     <% if comp.media %>

--- a/views/mdc/components/_checkbox.erb
+++ b/views/mdc/components/_checkbox.erb
@@ -17,7 +17,8 @@
            <% if comp.checked %>checked<% end %>
            <% if comp.disabled %>disabled<% end %>
            data-off="<%= comp.off_value %>"
-           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+           <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <div class="mdc-checkbox__background">
       <svg class="mdc-checkbox__checkmark"
            viewBox="0 0 24 24">

--- a/views/mdc/components/_chip.erb
+++ b/views/mdc/components/_chip.erb
@@ -30,7 +30,8 @@
           tabindex="0"
           <%= partial("components/event", locals: {comp: comp,
                                                 events: comp.events,
-                                                parent_id: comp.id}) if comp.events&.any? %>>
+                                                parent_id: comp.id}) if comp.events&.any? %>
+          <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <%= partial("components/icon", :locals => {comp: leading_icon,
                                             class_name: 'mdc-chip__icon mdc-chip__icon--leading',
                                             events: child_events ? (leading_icon&.events || comp.events) : nil}) if leading_icon %>

--- a/views/mdc/components/_chipset.erb
+++ b/views/mdc/components/_chipset.erb
@@ -12,6 +12,7 @@
      <%= drop_zone_attributes(comp) %>
      <%= partial("components/event", locals: {comp: comp,
                                            events: comp.events,
-                                           parent_id: comp.id}) if comp.events&.any? %>>
+                                           parent_id: comp.id}) if comp.events&.any? %>
+     <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>
 </div>

--- a/views/mdc/components/_datetime.erb
+++ b/views/mdc/components/_datetime.erb
@@ -22,7 +22,8 @@
          <%= 'required' if comp.required %>
          <%= "pattern='#{comp.pattern}'" if comp.pattern %>
          list="<%= comp.id %>-list"
-         <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} if comp.events&.any? %>>
+         <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} if comp.events&.any? %>
+         <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/icon", :locals => {comp: comp.clear_icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"}  if comp.picker && comp.clear_icon%>
   <%= partial "components/shared/input_label", :locals => {comp: comp} if comp %>
   <% if comp.picker %>

--- a/views/mdc/components/_dialog.erb
+++ b/views/mdc/components/_dialog.erb
@@ -11,7 +11,8 @@
      aria-labelledby="<%= comp.id %>-title"
      aria-describedby="<%= comp.id %>-content"
      data-is-container
-     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+     <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <div class="mdc-dialog__container"
     <% if comp.percent_width || comp.percent_height %>
       style="<%= "max-width: none; width: #{comp.percent_width}; " if comp.percent_width %>

--- a/views/mdc/components/_expansion_panel.erb
+++ b/views/mdc/components/_expansion_panel.erb
@@ -1,4 +1,4 @@
-<details id = '<%= comp.id %>' class="v-expansion mdc-elevation--z3"<% if comp.open %> open<% end %>>
+<details id = '<%= comp.id %>' class="v-expansion mdc-elevation--z3"<% if comp.open %> open<% end %> <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <summary class="v-expansion__summary">
     <% if comp.text&.text %>
       <%= partial "components/typography", :locals => {comp: comp.text, class_name: 'v-expansion__header', type: 'text', inline: comp.text&.inline} if comp.text %>

--- a/views/mdc/components/_file_input.erb
+++ b/views/mdc/components/_file_input.erb
@@ -5,7 +5,8 @@
        <% if comp.dirtyable %>data-dirtyable<% end %>
 
 
-       <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>>
+       <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>
+       <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <input id="<%= comp.id %>-input"
            name="<%= comp.name %>"
            type="file"

--- a/views/mdc/components/_form.erb
+++ b/views/mdc/components/_form.erb
@@ -7,6 +7,7 @@
       style='width: 100%'
       onsubmit="javascript:void(0);return false;"
       <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>
+      <%= partial 'components/shared/test_id', locals: {comp: comp} %>
       data-is-container>
   <div class="v-errors">
     <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>

--- a/views/mdc/components/_hidden_field.erb
+++ b/views/mdc/components/_hidden_field.erb
@@ -2,4 +2,5 @@
        type="hidden"
        <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
        <% if comp.dirtyable %>data-dirtyable<% end %>
-       id="<%= comp.id %>" name="<%= comp.name %>" value="<%= comp.value %>"/>
+       id="<%= comp.id %>" name="<%= comp.name %>" value="<%= comp.value %>"
+       <%= partial 'components/shared/test_id', locals: {comp: comp} %>/>

--- a/views/mdc/components/_icon.erb
+++ b/views/mdc/components/_icon.erb
@@ -27,7 +27,8 @@
       <%= "data-#{data}" if data %>
       style="<%= color_style(comp) %>"
       <%= 'tabindex="0"' if comp.events %>
-      <%= partial "components/event", :locals => {comp: comp, events: events, parent_id: parent_id} if events&.any? %>>
+      <%= partial "components/event", :locals => {comp: comp, events: events, parent_id: parent_id} if events&.any? %>
+      <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <%= icon %>
   </i>
   <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>

--- a/views/mdc/components/_icon_toggle.erb
+++ b/views/mdc/components/_icon_toggle.erb
@@ -9,7 +9,8 @@
    aria-label="" tabindex="0"
    data-name="<%= comp.name %>"
    data-off="<%= comp.off_value %>"
-   <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+   <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+   <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <i class="material-icons mdc-icon-button__icon mdc-icon-button__icon--on"><%= comp.on_icon  %></i>
   <i class="material-icons mdc-icon-button__icon"><%= comp.icon  %></i>
 </button>

--- a/views/mdc/components/_image.erb
+++ b/views/mdc/components/_image.erb
@@ -20,6 +20,7 @@
      <% if comp.description %>alt="<%= comp.description %>"<% end %>
      style="<%= styles.map { |k, v| "#{k}: #{v}" }.join('; ') %>"
      draggable="false"
-     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+     <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 <%= partial "components/tooltip" , :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>
 <% end %>

--- a/views/mdc/components/_image_list.erb
+++ b/views/mdc/components/_image_list.erb
@@ -25,7 +25,8 @@
              <% if image.description %>alt="<%= image.description %>"<% end %>
              style="<%= styles.map { |k, v| "#{k}: #{v}" }.join('; ') %>"
              draggable="false"
-             <%= partial "components/event", :locals => {comp: image, events: image.events, parent_id: image.event_parent_id} if image.events&.any? %>>
+             <%= partial "components/event", :locals => {comp: image, events: image.events, parent_id: image.event_parent_id} if image.events&.any? %>
+             <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
         <%= partial "components/tooltip" , :locals => {comp: image.tooltip, parent_id: image.id} if image.tooltip %>
       <% if comp.list_type != 'masonry' %></div><% end %>
       <% if image.label %>

--- a/views/mdc/components/_link.erb
+++ b/views/mdc/components/_link.erb
@@ -3,6 +3,7 @@
    id="<%= comp.id %>"
    target="<%= target %>"
    class="<%= comp.css_class.join(' ') %>"
-   <%= partial "components/event", locals: {comp: comp, events: comp.events, parent_id: comp.parent_id} if comp.events&.any? %>>
+   <%= partial "components/event", locals: {comp: comp, events: comp.events, parent_id: comp.parent_id} if comp.events&.any? %>
+   <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= comp.text %>
 </a>

--- a/views/mdc/components/_list.erb
+++ b/views/mdc/components/_list.erb
@@ -7,7 +7,8 @@
             <%= 'v-list__border' if comp.border %>"
       style="<%= "background-color: #{comp.color};" if comp.color %>"
       data-total-lines="<%= comp.total_lines %>"
-      <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>>
+      <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>
+      <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 <% end %>
 <% for line in comp.lines %>
   <%= partial "components/list/#{line.type}", :locals => {:list => comp, :line => line} %>

--- a/views/mdc/components/_menu.erb
+++ b/views/mdc/components/_menu.erb
@@ -24,7 +24,8 @@
               role="menuitem"
               tabindex="0"
               <%= 'disabled' if item.disabled %>
-              <%= partial "components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} if !item.disabled && item.events&.any? %>>
+              <%= partial "components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} if !item.disabled && item.events&.any? %>
+              <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
             <a class="v-menu-link"
                              id="<%= item.id %>"
                              href="javascript:void(0)">

--- a/views/mdc/components/_multi_select.erb
+++ b/views/mdc/components/_multi_select.erb
@@ -14,6 +14,7 @@
       class="mdc-select v-multi-select v-input <%= 'mdc-select--outlined' if comp.outlined %> <% 'mdc-select--disabled' if comp.disabled %>"
       <%= 'style="width: 100%;"' if comp.full_width %>
       <%= partial("components/event", locals: { comp: comp, events: comp.events, parent_id: "#{comp.id}-input" }) if comp.events&.any? %>
+      <%= partial 'components/shared/test_id', locals: {comp: comp} %>
     >
       <%= partial "components/icon", locals: { comp: comp.icon, class_name: 'mdc-select__icon', parent_id: "#{comp.id}-input", size_class: '', position: [] } if comp.icon %>
       <div class="v-multi-select--current-values"></div>

--- a/views/mdc/components/_number_field.erb
+++ b/views/mdc/components/_number_field.erb
@@ -28,7 +28,8 @@
            <%= 'required' if comp.required %>
            <%= "pattern='#{comp.pattern}'" if comp.pattern %>
            autocomplete="<%= auto_complete %>"
-           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: "#{comp.id}-input"} if comp.events&.any? %>>
+           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: "#{comp.id}-input"} if comp.events&.any? %>
+           <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 
     <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"} if comp.icon %>
     <%= partial "components/shared/input_label", :locals => {comp: comp} %>

--- a/views/mdc/components/_progress.erb
+++ b/views/mdc/components/_progress.erb
@@ -1,5 +1,6 @@
 <div id="<%= comp.id %>" role="progressbar" class="v-progress mdc-linear-progress mdc-linear-progress--indeterminate mdc-linear-progress--closed"
-     data-hidden="<%= comp.hidden %>">
+     data-hidden="<%= comp.hidden %>"
+     <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <div class="mdc-linear-progress__buffering-dots"></div>
   <div class="mdc-linear-progress__buffer"></div>
   <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">

--- a/views/mdc/components/_radio_button.erb
+++ b/views/mdc/components/_radio_button.erb
@@ -12,7 +12,8 @@
            name="<%= comp.name %>"
            <% if comp.checked %>checked<% end %>
            <% if comp.disabled %>disabled<% end %>
-           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+           <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <div class="mdc-radio__background">
       <div class="mdc-radio__outer-circle"></div>
       <div class="mdc-radio__inner-circle"></div>

--- a/views/mdc/components/_rich_text_area.erb
+++ b/views/mdc/components/_rich_text_area.erb
@@ -16,7 +16,8 @@
        data-img-max-height="<%= comp.img_max_height %>"
        data-server-upload-path="<%= comp.server_upload_path %>"
        data-server-upload-enabled="<%= comp.server_upload_enabled %>"
-       <%= "data-placeholder='#{comp.placeholder}'" if comp.placeholder %>>
+       <%= "data-placeholder='#{comp.placeholder}'" if comp.placeholder %>
+       <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <%= comp.value %>
   </div>
   <span class="mdl-textfield__error" ><%= comp.hint%></span>

--- a/views/mdc/components/_select.erb
+++ b/views/mdc/components/_select.erb
@@ -14,7 +14,8 @@
           class="mdc-select__native-control"
           <%= partial("components/event", locals: {comp: comp,
                                                 events: comp.events,
-                                                parent_id: "#{comp.id}-input"}) if comp.events&.any? %>>
+                                                parent_id: "#{comp.id}-input"}) if comp.events&.any? %>
+          <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <% comp.options.each do |option| %>
       <option value="<%= option.value %>"
               <%= 'disabled' if option.disabled %>

--- a/views/mdc/components/_slider.erb
+++ b/views/mdc/components/_slider.erb
@@ -17,7 +17,8 @@
      aria-valuenow="<%= comp.value unless comp.value.nil? %>"
      <% if comp.disabled %>aria-disabled<% end %>
      aria-label="Select Value"
-    <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: "#{comp.id}-input"} if comp.events&.any? %>>
+    <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: "#{comp.id}-input"} if comp.events&.any? %>
+    <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 <div class="mdc-slider__track-container">
     <div class="mdc-slider__track"></div>
 

--- a/views/mdc/components/_snackbar.erb
+++ b/views/mdc/components/_snackbar.erb
@@ -8,6 +8,7 @@
   <div id="<%=comp.id%>"
        class="v-hidden"
        aria-hidden="true"
-       data-events='<%= data_events.to_json %>'>
+       data-events='<%= data_events.to_json %>'
+       <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   </div>
 <% end %>

--- a/views/mdc/components/_stepper.erb
+++ b/views/mdc/components/_stepper.erb
@@ -23,7 +23,8 @@
            <% end %>
            class="v-content v-step__content v-step__content-<%= step.id %>
             <%= ' is-active' if step.selected %>
-            <%= ' v-step--horizontal' if horizontal %>">
+            <%= ' v-step--horizontal' if horizontal %>"
+            <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 
         <%= partial "components/render", :locals => {:components => step.components, :scope => nil} if step.components.any? %>
 

--- a/views/mdc/components/_switch.erb
+++ b/views/mdc/components/_switch.erb
@@ -20,7 +20,8 @@
                data-off="<%= comp.off_value %>"
                <%= ' checked ' if comp.checked %>
                <%= ' disabled ' if comp.disabled %>
-               <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>/>
+               <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+               <%= partial 'components/shared/test_id', locals: {comp: comp} %>/>
       </div>
     </div>
   </div>

--- a/views/mdc/components/_tab_bar.erb
+++ b/views/mdc/components/_tab_bar.erb
@@ -9,7 +9,8 @@
                     <%= 'mdc-tab--active' if tab.selected %>
                     <%= 'mdc-tab--stacked' if tab.stacked %>"
                   role="tab" aria-selected="<%= tab.selected %>" tabindex="0"
-                  <%= partial "components/event", :locals => {comp: tab, events: tab.events, parent_id: tab.event_parent_id} if tab.events&.any? %>>
+                  <%= partial "components/event", :locals => {comp: tab, events: tab.events, parent_id: tab.event_parent_id} if tab.events&.any? %>
+                  <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
           <span class="mdc-tab__content">
            <% if tab.icon %>
             <span class="mdc-tab__icon material-icons"><%= tab.icon %></span>

--- a/views/mdc/components/_table.erb
+++ b/views/mdc/components/_table.erb
@@ -1,6 +1,7 @@
 <div class="v-data-table mdc-data-table <%= 'v-no-border' unless comp.border %>" style="<%= "width:#{comp.width};" if comp.width %>">
   <table class="mdc-data-table__table"
-         <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>>
+         <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>
+         <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
     <% if comp.header %>
       <thead>
       <%= partial "components/table/header", :locals => {:row => comp.header} %>

--- a/views/mdc/components/_text_area.erb
+++ b/views/mdc/components/_text_area.erb
@@ -10,7 +10,8 @@
             <%= 'required' if comp.required %>
             rows="<%= comp.rows %>"
             cols="<%= comp.cols %>"
-            <% if comp.disabled %>disabled<% end %>><%= comp.value %></textarea>
+            <% if comp.disabled %>disabled<% end %>
+            <%= partial 'components/shared/test_id', locals: {comp: comp} %>><%= comp.value %></textarea>
   <%= partial "components/shared/input_label", :locals => {comp: comp} if comp %>
 </div>
 <%= partial "components/shared/hint_error_display", :locals => {comp: comp} if comp %>

--- a/views/mdc/components/_text_field.erb
+++ b/views/mdc/components/_text_field.erb
@@ -36,7 +36,8 @@
            <%= "tabindex='#{comp.tab_index}'" if comp.tab_index %>
            autocomplete="<%= auto_complete %>"
            list="<%= comp.id %>-list"
-           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} if comp.events&.any? %>>
+           <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} if comp.events&.any? %>
+           <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 
     <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-text-field__icon', parent_id: "#{comp.id}-input"} if comp.icon %>
 

--- a/views/mdc/components/_tooltip.erb
+++ b/views/mdc/components/_tooltip.erb
@@ -1,5 +1,5 @@
 <% if comp %>
-<div class="v-tooltip mdl-tooltip mdl-tooltip--<%=comp.position%>" for="<%=parent_id%>">
+<div class="v-tooltip mdl-tooltip mdl-tooltip--<%=comp.position%>" for="<%=parent_id%>" <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%=expand_text(comp.text.text)%>
 </div>
 <% end %>

--- a/views/mdc/components/_typography.erb
+++ b/views/mdc/components/_typography.erb
@@ -8,9 +8,10 @@
            <%= class_name %>
            <%= position_classes %>
            <%= 'v-actionable' if comp.events %>"
-     style = "<%= "color: #{comp.color};" if comp.color %>
+     style="<%= "color: #{comp.color};" if comp.color %>
               <%= "display: inline;" if comp.inline %>"
-     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+     <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>
+     <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/icon", :locals => {comp: comp.icon} if comp.icon %>
   <%= expand_text(comp.text, markdown: comp.markdown) %>
 </div>

--- a/views/mdc/components/_unordered_list.erb
+++ b/views/mdc/components/_unordered_list.erb
@@ -3,7 +3,8 @@
     class="icon-ul"
   <% else %>
     style="<%= "list-style: #{comp.list_style}" if comp.list_style %>"
-  <% end %>>
+  <% end %>
+  <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
 <% for item in comp.list_items %>
   <%= partial "components/unordered_list/list_item", :locals => {:list_item => item} %>
 <% end %>

--- a/views/mdc/components/buttons/_button.erb
+++ b/views/mdc/components/buttons/_button.erb
@@ -18,7 +18,8 @@
         data-disabled-on-post-finished="<%= comp.disabled_on_post_finished %>"
 <%= 'disabled ' if comp.disabled %>
 <%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
-<%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>>
+<%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
+<%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-button__icon'} if comp.icon %>
   <%= partial "components/image", :locals => {comp: comp.image} if comp.image %>
   <%= comp.text %>

--- a/views/mdc/components/buttons/_fab.erb
+++ b/views/mdc/components/buttons/_fab.erb
@@ -14,7 +14,8 @@
           <%= 'mdc-fab--mini' if eq(comp.size, :small) %>"
         aria-label="<%= inflector.humanize(comp.icon.icon) %>"
         <%= 'disabled' if comp.disabled %>
-        <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>>
+        <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
+        <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <span class="mdc-fab__icon">
   <%= comp.icon.icon %>
   </span>

--- a/views/mdc/components/buttons/_icon.erb
+++ b/views/mdc/components/buttons/_icon.erb
@@ -15,7 +15,8 @@
         style = "<%= color_style(comp) %>"
         <%= 'disabled' if comp.disabled %>
         <%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
-        <%= partial 'components/event', :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>>
+        <%= partial 'components/event', :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
+        <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial 'components/icon', :locals => {comp: comp.icon} if comp.icon %>
   <%= comp.text %>
   <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>

--- a/views/mdc/components/buttons/_image.erb
+++ b/views/mdc/components/buttons/_image.erb
@@ -18,7 +18,8 @@
   data-disabled-on-post-finished="<%= comp.disabled_on_post_finished %>"
   <%= 'disabled' if comp.disabled %>
   <%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
-  <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>>
+  <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} if comp.events&.any? %>
+  <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-button__icon', position: [:right, :center]} if comp.icon %>
 </button>
 <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>

--- a/views/mdc/components/list/_line.erb
+++ b/views/mdc/components/list/_line.erb
@@ -14,7 +14,8 @@
     id="<%= line.id %>"
     <%= draggable_attributes(line) %>
     <%= drop_zone_attributes(line) %>
-    <%= partial "components/event", :locals => {comp: line, events: line.events, parent_id: line.event_parent_id} if line.events&.any? %>>
+    <%= partial "components/event", :locals => {comp: line, events: line.events, parent_id: line.event_parent_id} if line.events&.any? %>
+    <%= partial 'components/shared/test_id', locals: {comp: line} %>>
   <%= partial "components/list/hidden_field", :locals => {:line => line} if line.hidden_field %>
   <%= partial "components/list/checkbox", :locals => {:line => line} if line.checkbox %>
   <%= partial "components/list/icon", :locals => {:line => line} if line.icon %>

--- a/views/mdc/components/list/_menu.erb
+++ b/views/mdc/components/list/_menu.erb
@@ -3,7 +3,8 @@
       <%= 'data-hoist="false"' if !comp.hoisted %>
       data-placement="contextual"
       style="position: absolute;"
-      tabindex="-1">
+      tabindex="-1"
+      <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <ul class="mdc-menu__items mdc-list" role="menu" aria-hidden="true">
     <% comp.items.each do |item| %>
       <% unless eq(item.type, :divider) %>
@@ -13,7 +14,8 @@
             <a class="v-menu-link"
                id="<%= item.id %>"
                href="javascript:void(0)"
-               <%= partial "components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} if item.events&.any? %>>
+               <%= partial "components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} if item.events&.any? %>
+               <%= partial 'components/shared/test_id', locals: {comp: item} %>>
           <% end %>
           <%= item.text %>
           <% unless item.disabled %>

--- a/views/mdc/components/shared/_test_id.erb
+++ b/views/mdc/components/shared/_test_id.erb
@@ -1,0 +1,3 @@
+<% if comp&.test_id %>
+  <%= Coprl::Presenters::Settings.config.presenters.web_client.test_id_attribute %>="<%= h comp&.test_id %>"
+<% end %>

--- a/views/mdc/components/table/_column.erb
+++ b/views/mdc/components/table/_column.erb
@@ -7,6 +7,7 @@
     class="<%= 'mdl-data-table__cell--non-numeric' unless col.numeric? %>
                <%= 'v-actionable' if col.events %>"
     <%= partial "components/event", :locals => {comp: col, events: col.events, parent_id: col.event_parent_id} if col.events&.any? %>
+    <%= partial 'components/shared/test_id', locals: {comp: col} %>
     style="<%= "background-color: #{col.color};" if col.color %>"
     <%= " colspan=#{col.colspan}" if col.colspan %>>
   <%= expand_text(col.value&.text) %>

--- a/views/mdc/components/table/_footer.erb
+++ b/views/mdc/components/table/_footer.erb
@@ -1,5 +1,6 @@
 <tr
-  style="<%= "background-color: #{row.color};" if row.color %>">
+  style="<%= "background-color: #{row.color};" if row.color %>"
+  <%= partial 'components/shared/test_id', locals: {comp: row} %>>
   <%= partial "components/table/checkbox", :locals => {:row=> row, :type=> 'footer'} %>
   <% row.columns.each do |col| %>
     <%= partial "components/table/column", :locals => {:col=> col, :type=> 'footer'} %>

--- a/views/mdc/components/table/_header.erb
+++ b/views/mdc/components/table/_header.erb
@@ -8,6 +8,7 @@
                <%= 'v-actionable' if col.events %>"
         role="columnheader" scope="col"
         <%= partial "components/event", :locals => {comp: col, events: col.events, parent_id: col.event_parent_id} if col.events&.any? %>
+        <%= partial 'components/shared/test_id', locals: {comp: col} %>
         style="<%= "background-color: #{col.color};" if col.color %>">
       <%= expand_text(col.value&.text) %>
       <%= partial "components/render", :locals => {:components => col.components, :scope => nil} if col.components.any? %>

--- a/views/mdc/components/table/_pagination.erb
+++ b/views/mdc/components/table/_pagination.erb
@@ -1,4 +1,4 @@
-<div class="v-paging">
+<div class="v-paging" <%= partial 'components/shared/test_id', locals: {comp: comp} %>>
   <span class="v-paging__per-page">
     <span class="v-paging__per-page-label">Rows per page: </span>
     <span class="v-paging__per-page-value"><%= partial "components/select", :locals => {:comp=> comp.per_page} %></span>

--- a/views/mdc/components/table/_row.erb
+++ b/views/mdc/components/table/_row.erb
@@ -7,6 +7,7 @@
                <%= "v-align-#{col.align}" %>
                <%= 'v-actionable' if col.events %>"
         <%= partial "components/event", :locals => {comp: col, events: col.events, parent_id: col.event_parent_id} if col.events&.any? %>
+        <%= partial 'components/shared/test_id', locals: {comp: col} %>
         style="<%= "background-color: #{col.color};" if col.color %>">
       <%= expand_text(col.value&.text, markdown: col.value&.markdown) %>
       <%= partial "components/render", :locals => {:components => col.components, :scope => nil} if col.components.any? %>


### PR DESCRIPTION
Introduces support for component test IDs, intended to be used for identification during automated test runs.

By default, components do not have a test ID. Callers can decorate components with a test ID via the `test_id` DSL attribute, present on all components:

```ruby
text_field name: :email_address, behavior: :email, test_id: :user_email do
  label 'E-mail address'
end
```

In the web client this will render HTML similar to the following:

```html
<input type="email" name="email_address" data-testid="user_email">
```

The default web client attribute name, `data-testid`, can be changed by setting the `presenters.web_client.test_id_attribute` configuration key:

```ruby
# config/initializers/coprl.rb
Coprl::Presenters::Settings.configure do |config|
  config.presenters.web_client.test_id_attribute = 'woof'
end
```

which (as expected) would result in:

```html
<input type="email" name="email_address" woof="user_email">
```

---

Closes #37.