### PR TITLE
feat(file_input): Decorate `file_input` when filled

### DIFF
--- a/lib/coprl/presenters/dsl/components/file_input.rb
+++ b/lib/coprl/presenters/dsl/components/file_input.rb
@@ -24,7 +24,9 @@ module Coprl
             return @value if locked?
             @value = value
           end
+
           private
+
           def default_button
             button(icon: :cloud_upload) unless components.any?
           end

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -60701,6 +60701,12 @@ var VFileInput = function (_dirtyableMixin) {
             return this.input.files[0];
         }
     }, {
+        key: 'clear',
+        value: function clear() {
+            this.input.value = null;
+            this.element.classList.remove('v-file-input--has-file');
+        }
+    }, {
         key: 'previewComponent',
         value: function previewComponent(e) {
             var _this2 = this;
@@ -60767,6 +60773,12 @@ var VFileInput = function (_dirtyableMixin) {
     }, {
         key: 'handleFileSelection',
         value: function handleFileSelection(e) {
+            if (e.target.files.length > 0) {
+                this.element.classList.add('v-file-input--has-file');
+            } else {
+                this.element.classList.remove('v-file-input--has-file');
+            }
+
             this.previewComponent(e);
         }
     }]);

--- a/public/wc.js
+++ b/public/wc.js
@@ -46107,6 +46107,12 @@ var VFileInput = function (_dirtyableMixin) {
             return this.input.files[0];
         }
     }, {
+        key: 'clear',
+        value: function clear() {
+            this.input.value = null;
+            this.element.classList.remove('v-file-input--has-file');
+        }
+    }, {
         key: 'previewComponent',
         value: function previewComponent(e) {
             var _this2 = this;
@@ -46173,6 +46179,12 @@ var VFileInput = function (_dirtyableMixin) {
     }, {
         key: 'handleFileSelection',
         value: function handleFileSelection(e) {
+            if (e.target.files.length > 0) {
+                this.element.classList.add('v-file-input--has-file');
+            } else {
+                this.element.classList.remove('v-file-input--has-file');
+            }
+
             this.previewComponent(e);
         }
     }]);

--- a/views/mdc/assets/js/components/file-inputs.js
+++ b/views/mdc/assets/js/components/file-inputs.js
@@ -33,6 +33,11 @@ export class VFileInput extends dirtyableMixin(eventHandlerMixin(VBaseComponent)
         return this.input.files[0];
     }
 
+    clear() {
+      this.input.value = null;
+      this.element.classList.remove('v-file-input--has-file');
+    }
+
     previewComponent(e) {
         if (!this.preview) return null;
         for (const previewId of this.preview) {
@@ -71,6 +76,13 @@ export class VFileInput extends dirtyableMixin(eventHandlerMixin(VBaseComponent)
 
     // From an example based on: https://www.quirksmode.org/dom/inputfile.html
     handleFileSelection(e) {
+        if (e.target.files.length > 0) {
+            this.element.classList.add('v-file-input--has-file');
+        }
+        else {
+            this.element.classList.remove('v-file-input--has-file');
+        }
+
         this.previewComponent(e);
     }
 }

--- a/views/mdc/components/_file_input.erb
+++ b/views/mdc/components/_file_input.erb
@@ -1,5 +1,5 @@
 <% if comp %>
-  <div id="<%= comp.id %>" class="v-input v-file-input"
+  <div id="<%= comp.id %>" class="v-input v-file-input <%= 'v-file-input--has-file' if comp.value %>"
        data-preview=<%= JSON.generate(Array(comp.preview)) %>
            data-accept="<%= comp.accept %>"
        <% if comp.dirtyable %>data-dirtyable<% end %>


### PR DESCRIPTION
In the web client, adds a `v-file-input--has-file` class to the `file_input` component when the user has selected a file. The class is removed when the input is cleared.