### PR TITLE
fix(snackbar): Make z-index !important

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -12093,7 +12093,7 @@ button.mdc-chip {
     margin-right: 8px; }
 
 .v-snackbar {
-  z-index: 9999; }
+  z-index: 9999 !important; }
 
 /**
  * mdl-stepper - A Material Design Lite Stepper component polyfill.

--- a/views/mdc/assets/scss/components/snackbar.scss
+++ b/views/mdc/assets/scss/components/snackbar.scss
@@ -1,5 +1,5 @@
 @import "@material/snackbar/mdc-snackbar";
 
-.v-snackbar{
-  z-index: 9999;
+.v-snackbar {
+  z-index: 9999 !important;
 }


### PR DESCRIPTION
The value defined in the web client (9999) is getting overridden by the theme plugin. It ends up being set back to the default value (14) which is below the dialog scrim.