### PR TITLE
fix(button): Fix button class name regression

### DIFF
--- a/views/mdc/components/_button.erb
+++ b/views/mdc/components/_button.erb
@@ -3,6 +3,7 @@
   event_parent_id = nil unless bound_locals_include?(:event_parent_id, binding)
   data_attributes = '' unless bound_locals_include?(:data_attributes, binding)
   parent_form = nil unless bound_locals_include?(:parent_form, binding)
+  class_name = "#{class_name} #{comp.css_class.join(' ')} #{comp.full_width ? 'v-button-full-width' : nil}"
   forwarded_locals = {
     class_name: class_name,
     event_parent_id: event_parent_id,
@@ -10,25 +11,23 @@
     parent_form: parent_form
   }
 %>
-<% if comp
-     class_name = "#{class_name} #{comp.css_class.join(' ')} #{comp.full_width ? 'v-button-full-width' : nil}"
+<% if comp.menu %>
+  <div class="mdc-menu-anchor">
+<% end %>
+<%
+  case comp.button_type.to_sym
+  when :fab
+    %><%= partial "components/buttons/fab", locals: {comp: comp, **forwarded_locals} %><%
+  when :icon
+    %><%= partial "components/buttons/icon", locals: {comp: comp, **forwarded_locals} %><%
+  when :image
+    %><%= partial "components/buttons/image", locals: {comp: comp, **forwarded_locals} %><%
+  else
+    %><%= partial "components/buttons/button", locals: {comp: comp, **forwarded_locals} %><%
+  end
 %>
-  <% if comp.menu %>
-    <div class="mdc-menu-anchor">
-  <% end %>
-  <% case comp.button_type.to_sym
-        when :fab %>
-            <%= partial "components/buttons/fab", :locals => {:comp => comp, **forwarded_locals} if comp %>
-     <% when :icon %>
-            <%= partial "components/buttons/icon", :locals => {:comp => comp, **forwarded_locals} if comp %>
-    <% when :image %>
-            <%= partial "components/buttons/image", :locals => {:comp => comp, **forwarded_locals} if comp %>
-    <% else  %>
-            <%= partial "components/buttons/button", :locals => {:comp => comp, **forwarded_locals} if comp %>
-  <% end %>
-  <% if comp.menu %>
-    </div>
-  <% end %>
+<% if comp.menu %>
+  </div>
 <% end %>
 
 


### PR DESCRIPTION
Ensure `class_name` is mutated before it's added to the `forwarded_locals` hash.

Fixes #62.