### PR TITLE
Fix plugins for Rails

### DIFF
--- a/lib/coprl/presenters/rails/concerns/coprl_partial.rb
+++ b/lib/coprl/presenters/rails/concerns/coprl_partial.rb
@@ -10,9 +10,9 @@ module Coprl
           end
           
           module ClassMethods
-            @plugins = []
             def presenter_plugin(*plugins)
-              @plugins += Array(plugins)
+              @plugins ||= []
+              @plugins.push(*plugins)
             end
 
             def plugins
@@ -22,6 +22,7 @@ module Coprl
 
           def set_view_path
             paths = Coprl::Presenters::WebClient::PluginViewsPath.new(pom: nil, plugins: self.class.plugins).render
+
             paths.each do |path|
               prepend_view_path path
             end


### PR DESCRIPTION
This allows us to use `presenter_plugins` from within Rails controllers to tell COPRL to render the correct headers and include the plugins in the view search paths.

Instance variable need to be set within methods. They cannot be set in the class.