### PR TITLE
Reduce string allocations in hot code paths

### DIFF
--- a/lib/coprl/presenters/pluggable.rb
+++ b/lib/coprl/presenters/pluggable.rb
@@ -1,36 +1,66 @@
+# frozen_string_literal: true
+
 include Coprl::Trace
 
 module Coprl
   module Presenters
     module Pluggable
-      def include_plugins(*layers, plugins: [],
-                          plugin_method: method(:include))
+      def include_plugins(*layers, plugins: [], plugin_method: method(:include))
         plugins = Array(plugins) + Array(Coprl::Presenters::Settings.config.presenters.plugins)
         plugins.uniq.each do |plugin|
-          plugin(plugin, *layers, plugin_method: plugin_method)
+          plugin(plugin, layers, plugin_method: plugin_method)
         end
       end
-
 
       # Returns the module for the specified plugin. If the module is not
       # defined, the corresponding plugin required.
       def plugin_module(plugin)
-        module_name = plugin.to_s.gsub(/(^|_)(.)/) {|x| x[-1..-1].upcase}
+        @plugin_name_cache ||= {}
+        @plugin_name_cache[plugin] ||= classify(plugin)
+        module_name = @plugin_name_cache[plugin]
+
         unless Coprl::Presenters::Plugins.const_defined?(module_name, false)
-          trace {"Method plugin loading plugin: #{plugin}"}
           load "coprl/presenters/plugins/#{plugin}.rb"
         end
+
         Coprl::Presenters::Plugins.const_get(module_name)
       end
 
-      def plugin(plugin, *layers, plugin_method: method(:include))
+      def plugin(plugin, layers, plugin_method: method(:include))
         m = plugin.is_a?(Module) ? plugin : plugin_module(plugin)
         layers.each do |layer|
           if m.const_defined?(layer, false) && !self.const_defined?(layer, false)
-            trace {"Injecting plugin(#{m.const_get(layer).inspect}) into #{self.inspect}!"}
             plugin_method.call(m.const_get(layer))
           end
         end
+      end
+
+      # a multibyte-unaware method for converting a snake_case string to a PascalCase const name.
+      # note that this method is optimized to minimize allocations – please be wary of this when
+      # refactoring.
+      def classify(plugin_name)
+        string = plugin_name.to_s
+        result = +"" # mutable string
+        capitalize_next = true
+        len = string.length # cache string length to avoid multiple calls
+        i = 0
+
+        # the following is equivalent to String#each_char. however, each_char allocates and yields
+        # a string of length 1 to its enumerator, which is undesirable here.
+        while i < len
+          char = string[i]
+
+          if char.ord == 95 # underscore
+            capitalize_next = true
+          else
+            result << (capitalize_next ? char.upcase : char)
+            capitalize_next = false
+          end
+
+          i += 1
+        end
+
+        result
       end
     end
   end

--- a/lib/coprl/presenters/web_client/plugin_headers.rb
+++ b/lib/coprl/presenters/web_client/plugin_headers.rb
@@ -15,25 +15,23 @@ module Coprl
         end
 
         def render
-          results = ""
+          results = StringIO.new
 
           header_plugins.each do |plugin|
             header_method = :"render_header_#{plugin}"
-            results << "<!-- Headers for #{plugin} -->\n"
+
             if respond_to?(header_method)
-              results << send(header_method,
-                @pom,
-                render: @render)
+              results << send(header_method, @pom, render: @render)
             end
           end
-          results
+
+          results.string
         end
 
         private
 
         def header_plugins
-          (plugins + Coprl::Presenters::Settings.config.presenters.plugins)
-            .uniq
+          @header_plugins ||= (plugins + Coprl::Presenters::Settings.config.presenters.plugins).uniq
         end
 
         def plugins


### PR DESCRIPTION
Profiling via [memory_profiler](https://github.com/SamSaffron/memory_profiler) revealed that a large portion of allocations for a POM-rendering request came from `Pluggable` loading plugins and `PluginHeaders` rendering their headers. This attempts to reduce allocations in those code paths.

<details>
<summary>before</summary>

    allocated memory by file
    -----------------------------------
    ... omitted ...
    17196144  gems/coprl-855faa8b26e9/lib/coprl/presenters/pluggable.rb
    ... omitted ...
    1576992  gems/coprl-855faa8b26e9/lib/coprl/presenters/web_client/plugin_headers.rb
    ... omitted ...

    allocated memory by location
    -----------------------------------
    ... omitted ...
    11546880  gems/2.7.0/bundler/gems/coprl-855faa8b26e9/lib/coprl/presenters/pluggable.rb:18
    ... omitted ...
    4469760   gems/2.7.0/bundler/gems/coprl-855faa8b26e9/lib/coprl/presenters/pluggable.rb:10
    ... omitted ...
    1572904   gems/coprl-855faa8b26e9/lib/coprl/presenters/web_client/plugin_headers.rb:18
    ... omitted ...

</details>

<details>
<summary>after</summary>

    allocated memory by file
    -----------------------------------
    ... omitted ...
    1577966  gems/coprl-1ad5561d414d/lib/coprl/presenters/web_client/plugin_headers.rb
    ... omitted ...
    793386  gems/coprl-1ad5561d414d/lib/coprl/presenters/pluggable.rb
    ... omitted ...

    allocated memory by location
    -----------------------------------
    ... omitted ...
    1572984  gems/coprl-1ad5561d414d/lib/coprl/presenters/web_client/plugin_headers.rb:18
    ... omitted ...


`pluggable.rb` is no longer in the top 50.
</details>